### PR TITLE
Allow substitution of values in title validator message

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,12 @@ insertIssueLinkInPrDescription:
 verifyTitles:
   # Regular expression that should be matched by titles of commits or PR
   titleRegexp: ^\[AIRFLOW-[0-9]{4}\].*$|^\[AIRFLOW-XXXX\].*$
+  # If set to true, it will only ever check the PR title (and validateEitherPrOrSingleCommitTitle is ignored).
+  onlyValidatePrTitle: false
   # If set to true, it will only check the commit in case there is a single commit.
   # In case of multiple commits it will check PR title.
   # This reflects the standard behaviour of Github that for `Squash & Merge` GitHub
-  # takes the title of the squashed commit from PR title rather than from commit message ¯\_(ツ)_/¯
+  # uses the PR title rather than commit messages for the squashed commit ¯\_(ツ)_/¯
   # For single-commit PRs it takes the squashed commit message from the commit as expected.
   #
   # If set to false it will check all commit messages. This is useful when you do not squash commits at merge.

--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ verifyTitles:
   #
   # If set to false it will check all commit messages. This is useful when you do not squash commits at merge.
   validateEitherPrOrSingleCommitTitle: true
+  # Message to display to users when validation fails.
+  # Allows insertion of {type} (will be commit or PR), {title} (the title validated) and {regex} (the titleRegexp above).
+  errorDescription: "Wrong {type} title: {title}"
 
 ###### PR/Branch Up-To-Date Checker ####################################################################################
 # Check if the branch is up to date with master when certain files are modified

--- a/lib/title_validator.js
+++ b/lib/title_validator.js
@@ -5,7 +5,6 @@
  */
 async function verifyTitles (context, config) {
   const configKey = 'verifyTitles'
-  const titleValidatorName = 'Title Validator'
 
   if (configKey in config) {
     const verifyTitles = config[configKey]
@@ -13,7 +12,7 @@ async function verifyTitles (context, config) {
     const alwaysUsePrTitle = verifyTitles.alwaysUsePrTitle
     const validateEitherPrOrSingleCommitTitle =
         verifyTitles.validateEitherPrOrSingleCommitTitle
-    const statusTitle = verifyTitles.statusTitle || titleValidatorName
+    const statusTitle = verifyTitles.statusTitle || 'Title Validator'
     const successMessage = verifyTitles.successMessage || 'Validation successful!'
     const failureMessage = verifyTitles.failureMessage || 'Wrong ${type} title: ${title}'
     
@@ -22,83 +21,69 @@ async function verifyTitles (context, config) {
     const pr = getPr.data
     context.log.info('Fetched PR for Title Validator: ', pr.url)
 
-    /**
-     *
-     * Generate a description for the github status
-     * @param {string} type     Should be either PR or Commit
-     * @param {string} title    The title that was invalid
-     * @returns {string}        A description to display to the end user
-     */
-    function _getDescription(type, title) {
-
-      // Easy way of doing replace all
-      return failureMessage
-        .split('${type}').join(type)
-        .split('${title}').join(title)
-        .split('${regex}').join(commitTitleRegexp.toString())
-
-    }
-
     // Get commits in the PR
     const commits = await context.github.pulls.listCommits(issue)
     const messages = commits.data.map(commit => commit.commit.message)
-    let valid = true
+    
     if (!alwaysUsePrTitle && messages.length === 0) {
       context.log.warn('No commits in PR ?????')
-      const params = {
-        sha: pr.head.sha,
-        context: statusTitle,
-        state: 'failure',
-        description: 'No commits ?????'
-      }
-      context.github.repos.createStatus(context.repo(params))
-      valid = false
-    } else if (alwaysUsePrTitle || (validateEitherPrOrSingleCommitTitle && messages.length !== 1)) {
+      await _createStatus(context, pr.head.sha, statusTitle, 'failure', 'No commits ?????')
+      return
+    }  
+
+    // Use PR title by default
+    let titles = [pr.title]
+    let type = 'PR'
+    if (alwaysUsePrTitle || (validateEitherPrOrSingleCommitTitle && messages.length !== 1)) {
       context.log.info(`Validating PR title only: ${pr.title}`)
-      const regexpMatch = commitTitleRegexp.exec(pr.title)
-      if (regexpMatch == null) {
-        context.log.info('PR title is wrong:', pr.title)
-        const params = {
-          sha: pr.head.sha,
-          context: statusTitle,
-          state: 'failure',
-          description: _getDescription("PR", pr.title)
-        }
-        context.github.repos.createStatus(context.repo(params))
-        valid = false
-      }
     } else {
       context.log.info(`Validating ${messages.length} commits`)
-      for (const messageIndex in messages) {
-        const commitTitle = messages[messageIndex].split('\n')[0]
-        context.log.info(`Validating ${commitTitle}`)
-        const regexpMatch = commitTitleRegexp.exec(commitTitle)
-        if (regexpMatch == null) {
-          context.log.info('Commit title is wrong:', commitTitle)
-          const params = {
-            sha: pr.head.sha,
-            context: statusTitle,
-            state: 'failure',
-            description: _getDescription("commit", commitTitle)
-          }
-          // Create the status
-          context.github.repos.createStatus(context.repo(params))
-          valid = false
-          break
-        }
+      titles = messages.map(m => m.split('\n')[0])
+      type = 'Commit'
+    }
+
+    // Check titles and raise a failure on the first invalid title.
+    for (const title of titles) {
+      context.log.info(`Validating ${title}`)
+      const regexpMatch = commitTitleRegexp.exec(title)
+      if (regexpMatch == null) {
+        context.log.info(`${type} title is wrong:`, title)
+
+        // Easy way of doing replace all
+        const message = failureMessage
+        .split('${type}').join(type)
+        .split('${title}').join(title)
+        .split('${regex}').join(commitTitleRegexp.toString())
+        
+        // Create the status
+        await _createStatus(context, pr.head.sha, statusTitle, 'failure', message)
+        return
       }
     }
-    if (valid) {
+
+    // Only valid states remain
       context.log.info('Commit/PR titles are OK')
-      const params = {
-        sha: pr.head.sha,
-        context: statusTitle,
-        state: 'success',
-        description: successMessage
-      }
-      context.github.repos.createStatus(context.repo(params))
-    }
+      await _createStatus(context, pr.head.sha, statusTitle, 'success', successMessage)
   }
+}
+
+/**
+ * Create a github status for the PR with the given state and description
+ * @param {import('probot').Context} context  Context used to post the status
+ * @param {string} sha                        The commit hash to post the status against
+ * @param {string} statusTitle                The title of the check
+ * @param {string} state                      The status to post, typically 'success' or 'failure'
+ * @param {string} description                The description for the status
+ */
+async function _createStatus(context, sha, statusTitle, state, description)
+{
+  const params = {
+    sha: sha,
+    context: statusTitle,
+    state: state,
+    description: description
+  }
+  await context.github.repos.createStatus(context.repo(params))
 }
 
 module.exports = {

--- a/lib/title_validator.js
+++ b/lib/title_validator.js
@@ -13,10 +13,29 @@ async function verifyTitles (context, config) {
     const onlyValidatePrTitle = verifyTitles.onlyValidatePrTitle
     const validateEitherPrOrSingleCommitTitle =
         verifyTitles.validateEitherPrOrSingleCommitTitle
+    const description = verifyTitles.errorDescription || "Wrong {type} title: {title}"
+
     const issue = await context.issue()
     const getPr = await context.github.pulls.get(issue)
     const pr = getPr.data
     context.log.info('Fetched PR for Title Validator: ', pr.url)
+
+    /**
+     *
+     * Generate a description for the github status
+     * @param {string} type     Should be either PR or Commit
+     * @param {string} title    The title that was invalid
+     * @returns {string}        A description to display to the end user
+     */
+    function _getDescription(type, title) {
+
+      // Easy way of doing replace all
+      return description
+        .split("{type}").join(type)
+        .split("{title}").join(title)
+        .split("{regex}").join(commitTitleRegexp.toString())
+
+    }
 
     // Get commits in the PR
     const commits = await context.github.pulls.listCommits(issue)
@@ -41,7 +60,7 @@ async function verifyTitles (context, config) {
           sha: pr.head.sha,
           context: titleValidatorName,
           state: 'failure',
-          description: `Wrong PR title: ${pr.title}`
+          description: _getDescription("PR", pr.title)
         }
         context.github.repos.createStatus(context.repo(params))
         valid = false
@@ -58,7 +77,7 @@ async function verifyTitles (context, config) {
             sha: pr.head.sha,
             context: titleValidatorName,
             state: 'failure',
-            description: `Wrong commit title: ${commitTitle}`
+            description: _getDescription("commit", commitTitle)
           }
           // Create the status
           context.github.repos.createStatus(context.repo(params))

--- a/lib/title_validator.js
+++ b/lib/title_validator.js
@@ -10,6 +10,7 @@ async function verifyTitles (context, config) {
   if (configKey in config) {
     const verifyTitles = config[configKey]
     const commitTitleRegexp = new RegExp(verifyTitles.titleRegexp)
+    const onlyValidatePrTitle = verifyTitles.onlyValidatePrTitle
     const validateEitherPrOrSingleCommitTitle =
         verifyTitles.validateEitherPrOrSingleCommitTitle
     const issue = await context.issue()
@@ -21,7 +22,7 @@ async function verifyTitles (context, config) {
     const commits = await context.github.pulls.listCommits(issue)
     const messages = commits.data.map(commit => commit.commit.message)
     let valid = true
-    if (messages.length === 0) {
+    if (!onlyValidatePrTitle && messages.length === 0) {
       context.log.warn('No commits in PR ?????')
       const params = {
         sha: pr.head.sha,
@@ -31,7 +32,7 @@ async function verifyTitles (context, config) {
       }
       context.github.repos.createStatus(context.repo(params))
       valid = false
-    } else if (validateEitherPrOrSingleCommitTitle && messages.length !== 1) {
+    } else if (onlyValidatePrTitle || validateEitherPrOrSingleCommitTitle && messages.length !== 1) {
       context.log.info(`Validating PR title only: ${pr.title}`)
       const regexpMatch = commitTitleRegexp.exec(pr.title)
       if (regexpMatch == null) {


### PR DESCRIPTION
It would appear that @reececomo and I had the same idea, as I went to raise a PR last night to allow users to always use the PR title for message validation, and set the failure message of the check, only to find he'd already done it the day prior 😂 

After merging the changes and dealing with the conflicts, the only bit of functionality not already implemented was the ability for the user to substitute the following placeholders into the failure description:

- Type of entity checked (PR or commit)
- Message/title that failed validation
- The regex used to validate messages/titles
