### PR TITLE
Fix first time contributor detection with time constraints

### DIFF
--- a/lib/greetings.js
+++ b/lib/greetings.js
@@ -13,11 +13,11 @@ async function commentOnfirstPR (context, config) {
 
     context.log.info(`Fetching PRs for greetings for Author: ${author}`)
 
-    // Get list of all PRs that the author has created
+    // Get list of all PRs that the author has created before this PR
     const allPRs = new Set()
     await context.octokit.paginate(
       context.octokit.search.issuesAndPullRequests.endpoint.merge({
-        q: `is:pr author:${author} repo:${repo}`
+        q: `is:pr author:${author} repo:${repo} created:<${context.payload.pull_request.created_at}`
       }),
       res => (res.data.items || []).forEach(pr => { allPRs.add(pr) })
     )
@@ -53,13 +53,13 @@ async function commentOnfirstPRMerge (context, config) {
       const author = context.payload.pull_request.user.login
       const repo = context.payload.repository.full_name
 
-      context.log.info(`Fetching PRs for Author: ${author}`)
+      context.log.info(`Fetching merged PRs for Author: ${author}`)
 
-      // Get list of all merged PRs that the author has created
+      // Get list of all merged PRs that the author has created before this one
       const allMergedPRs = new Set()
       await context.octokit.paginate(
         context.octokit.search.issuesAndPullRequests.endpoint.merge({
-          q: `is:pr is:merged author:${author} repo:${repo}`
+          q: `is:pr is:merged author:${author} repo:${repo} merged:<${context.payload.pull_request.merged_at}`
         }),
         res => (res.data.items || []).forEach(pr => { allMergedPRs.add(pr) })
       )
@@ -100,11 +100,11 @@ async function commentOnfirstIssue (context, config) {
 
     context.log.info(`Fetching Issues created by Author: ${author}`)
 
-    // Get list of all issues that the author has created
+    // Get list of all issues that the author has created before this PR
     const allIssues = new Set()
     await context.octokit.paginate(
       context.octokit.search.issuesAndPullRequests.endpoint.merge({
-        q: `is:issue author:${author} repo:${repo}`
+        q: `is:issue author:${author} repo:${repo} created:<${context.payload.issue.created_at}`
       }),
       res => (res.data.items || []).forEach(issue => { allIssues.add(issue) })
     )

--- a/test/greetings.test.js
+++ b/test/greetings.test.js
@@ -10,7 +10,9 @@ describe('greetings', () => {
           user: { login: 'testuser' },
           number: 1,
           html_url: 'https://github.com/owner/repo/pull/1',
-          merged: false
+          merged: false,
+          created_at: '2024-01-01T00:00:00Z',
+          merged_at: '2024-01-02T00:00:00Z'
         },
         repository: {
           full_name: 'owner/repo'
@@ -18,7 +20,8 @@ describe('greetings', () => {
         issue: {
           user: { login: 'testuser' },
           number: 1,
-          html_url: 'https://github.com/owner/repo/issues/1'
+          html_url: 'https://github.com/owner/repo/issues/1',
+          created_at: '2024-01-01T00:00:00Z'
         }
       },
       log: {
@@ -50,7 +53,7 @@ describe('greetings', () => {
       }
 
       context.octokit.search.issuesAndPullRequests.endpoint.merge.mockReturnValue({
-        q: 'is:pr author:testuser repo:owner/repo'
+        q: 'is:pr author:testuser repo:owner/repo created:<2024-01-01T00:00:00Z'
       })
       context.octokit.paginate.mockImplementation((endpoint, callback) => {
         // No callback means no existing PRs, so Set remains empty
@@ -75,7 +78,7 @@ describe('greetings', () => {
       }
 
       context.octokit.search.issuesAndPullRequests.endpoint.merge.mockReturnValue({
-        q: 'is:pr author:testuser repo:owner/repo'
+        q: 'is:pr author:testuser repo:owner/repo created:<2024-01-01T00:00:00Z'
       })
       context.octokit.paginate.mockImplementation((endpoint, callback) => {
         if (callback) {
@@ -108,7 +111,7 @@ describe('greetings', () => {
 
       context.payload.pull_request.merged = true
       context.octokit.search.issuesAndPullRequests.endpoint.merge.mockReturnValue({
-        q: 'is:pr is:merged author:testuser repo:owner/repo'
+        q: 'is:pr is:merged author:testuser repo:owner/repo merged:<2024-01-02T00:00:00Z'
       })
       context.octokit.paginate.mockImplementation((endpoint, callback) => {
         // No callback means no existing PRs, so Set remains empty
@@ -148,7 +151,7 @@ describe('greetings', () => {
       }
 
       context.octokit.search.issuesAndPullRequests.endpoint.merge.mockReturnValue({
-        q: 'is:issue author:testuser repo:owner/repo'
+        q: 'is:issue author:testuser repo:owner/repo created:<2024-01-01T00:00:00Z'
       })
       context.octokit.paginate.mockImplementation((endpoint, callback) => {
         // No callback means no existing issues, so Set remains empty
@@ -173,7 +176,7 @@ describe('greetings', () => {
       }
 
       context.octokit.search.issuesAndPullRequests.endpoint.merge.mockReturnValue({
-        q: 'is:issue author:testuser repo:owner/repo'
+        q: 'is:issue author:testuser repo:owner/repo created:<2024-01-01T00:00:00Z'
       })
       context.octokit.paginate.mockImplementation((endpoint, callback) => {
         if (callback) {


### PR DESCRIPTION
I am attempting to fix an issue where seasoned developers are getting the first PR welcome messages from boring cyborg. Example:

https://github.com/apache/airflow/pull/51568: new merge message

https://github.com/apache/airflow/pull/51639: first PR message


The issue seems to be that prior to https://github.com/kaxil/boring-cyborg/commit/bf2ed3f004c5466db3913e263ee923cbf24fa97c#diff-2246d6bc20982f5f3edcd6f28b634c1af98104bd5700c154abc00209f9e1f454, github api was used to detect
the first contributor's, but its replaced with octokit now.

The GitHub Search API has a default ordering behaviour where

> GitHub's Search API by default sorts results by defaulting to sorting by most recently created/updated first.

But octokit doesn't do that. So, using an explicit temporal constraint guarantees we only look at PRs that existed before the current one and it is a more fool-proof way too.

