### PR TITLE
Add initial PR feature to establish bot as recognised contributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ automated comment.
 * Check if a branch is up to date with the master when specific files are modified in the PR.
 This is helpful when you desire the changes to be applied sequentially, for example, alembic migrations.
 * Add reviewers to PR based on labels present on the PR. This is especially helpful if you are auto-assigning labels based on functional areas of ownership.
+* Automatically establish `boring-cyborg[bot]` as a recognised contributor so its workflow runs
+no longer require manual approval (see [Recognised Contributor PR](#recognised-contributor-pr) below).
 
 ## Usage
 
@@ -142,6 +144,49 @@ checkUpToDate:
 ```
 
 All the features are optional. Simply add the config for the feature you want to use.
+
+###### Recognised Contributor PR #######################################################################################
+
+GitHub requires manual approval for workflow runs triggered by first-time contributors. This means
+that when boring-cyborg is first installed (or upgraded), any workflows it triggers may need a
+maintainer to click "Approve" before they run.
+
+To solve this automatically, boring-cyborg can create a one-time PR from a fork that adds a
+`boringCyborgAsRecognisedContributor: true` flag to your `.github/boring-cyborg.yml`. Once you
+merge that PR, GitHub recognises `boring-cyborg[bot]` as a past contributor and stops requiring
+manual approval for its workflow runs.
+
+**How it works:**
+
+1. On certain events (PR opened, app installed, app upgraded, repos added to installation),
+   boring-cyborg reads your `.github/boring-cyborg.yml`.
+2. If `boringCyborgAsRecognisedContributor: true` is already present, it does nothing.
+3. If the flag is missing or set to `false`, and boring-cyborg has no existing PRs in the repo,
+   it forks the repo, adds the flag, and opens a cross-fork PR.
+4. A maintainer reviews and merges the PR — boring-cyborg is now a recognised contributor.
+
+**To opt in** (for repos where boring-cyborg is already installed), add the flag set to `false`
+in your `.github/boring-cyborg.yml`:
+
+```yaml
+# Set to false to request boring-cyborg to create a PR that establishes it
+# as a recognised contributor (so its workflow runs don't need manual approval).
+# Once the PR is merged, the flag will be set to true automatically.
+boringCyborgAsRecognisedContributor: false
+```
+
+**To skip** (if you don't need this), add the flag set to `true`:
+
+```yaml
+# boring-cyborg is already a recognised contributor — no initial PR needed.
+boringCyborgAsRecognisedContributor: true
+```
+
+If the flag is absent entirely, boring-cyborg will also attempt to create the PR (since the
+contributor status has not been established yet).
+
+> **Note:** This feature uses a fork-based approach and only requires `contents: read` permission
+> on your repository — it does **not** need `contents: write`.
 
 ## Setup
 

--- a/app.yml
+++ b/app.yml
@@ -23,6 +23,8 @@ default_events:
   # - fork
   # - gollum
   # - issue_comment
+  - installation
+  - installation_repositories
   - issues
   - label
   # - milestone
@@ -62,7 +64,8 @@ default_permissions:
 
   # Repository contents, commits, branches, downloads, releases, and merges.
   # https://developer.github.com/v3/apps/permissions/#permission-on-contents
-  # contents: read
+  # Required for forking repos to create initial PRs and reading config files.
+  contents: read
 
   # Deployments and deployment statuses.
   # https://developer.github.com/v3/apps/permissions/#permission-on-deployments

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const greetings = require('./lib/greetings')
 const issuelink = require('./lib/issuelink')
 const titleValidator = require('./lib/title_validator')
 const upToDateChecker = require('./lib/up_to_date_checker')
+const initialPr = require('./lib/initial_pr')
 const utils = require('./lib/utils')
 
 module.exports = (app, { getRouter }) => {
@@ -81,6 +82,21 @@ module.exports = (app, { getRouter }) => {
     'pull_request.synchronize'], async context => {
     const config = await utils.getConfig(context)
     await upToDateChecker.checkUpToDate(context, config)
+  })
+
+  // "Initial PR" - Create an initial PR from a fork to establish boring-cyborg
+  // as a recognized contributor, so its workflow runs don't require manual approval.
+  // Triggered on PR open (piggybacks on existing events) and on installation
+  // created/updated events (covers new installs and app upgrades).
+  app.on('pull_request.opened', async context => {
+    await initialPr.createInitialPR(context)
+  })
+
+  app.on([
+    'installation.created',
+    'installation.new_permissions_accepted',
+    'installation_repositories.added'], async context => {
+    await initialPr.createInitialPROnInstall(context)
   })
 
   // Only register the /stats endpoint if getRouter is provided and returns a router

--- a/lib/initial_pr.js
+++ b/lib/initial_pr.js
@@ -1,0 +1,297 @@
+const INITIAL_PR_BRANCH = 'boring-cyborg-initial-setup'
+
+const CONFIG_FLAG = 'boringCyborgAsRecognisedContributor'
+
+/**
+ * Sleep for the specified number of milliseconds
+ * @param {number} ms
+ */
+function sleep (ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+/**
+ * Wait for a fork to be ready by polling the repo endpoint
+ * @param {import('@octokit/rest').Octokit} octokit
+ * @param {string} owner
+ * @param {string} repo
+ * @param {object} log
+ * @param {number} maxAttempts
+ */
+async function waitForFork (octokit, owner, repo, log, maxAttempts = 10) {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      await octokit.rest.repos.get({ owner, repo })
+      log.info(`Fork ${owner}/${repo} is ready`)
+      return
+    } catch (e) {
+      log.info(`Waiting for fork to be ready (attempt ${i + 1}/${maxAttempts})...`)
+      await sleep(3000)
+    }
+  }
+  throw new Error(`Fork ${owner}/${repo} was not ready after ${maxAttempts} attempts`)
+}
+
+/**
+ * Check if boring-cyborg[bot] already has an open or merged PR in the repo
+ * @param {import('@octokit/rest').Octokit} octokit
+ * @param {string} owner
+ * @param {string} repo
+ * @param {object} log
+ * @returns {boolean}
+ */
+async function hasExistingPR (octokit, owner, repo, log) {
+  try {
+    const searchResult = await octokit.rest.search.issuesAndPullRequests({
+      q: `is:pr repo:${owner}/${repo} author:app/boring-cyborg`,
+      per_page: 1
+    })
+    const count = searchResult.data.total_count
+    log.info(`Found ${count} existing PRs from boring-cyborg in ${owner}/${repo}`)
+    return count > 0
+  } catch (e) {
+    log.warn(`Failed to search for existing PRs: ${e.message}`)
+    return false
+  }
+}
+
+/**
+ * Create an initial PR from a fork to establish boring-cyborg as a contributor.
+ * Once merged, boring-cyborg's workflow runs will no longer require manual approval.
+ *
+ * This works by forking the repo (no contents:write needed on the target), pushing
+ * a small config change to the fork, and opening a cross-fork PR.
+ *
+ * The PR is created when the config does not contain the
+ * `boringCyborgAsRecognisedContributor: true` flag, indicating boring-cyborg
+ * has not yet been established as a contributor via this mechanism.
+ *
+ * @param {import('@octokit/rest').Octokit} octokit
+ * @param {string} owner
+ * @param {string} repo
+ * @param {string} defaultBranch
+ * @param {object} log
+ */
+async function createInitialPRForRepo (octokit, owner, repo, defaultBranch, log) {
+  log.info(`Checking if initial PR is needed for ${owner}/${repo}`)
+
+  // Read the existing boring-cyborg.yml content
+  let existingContent = null
+  try {
+    const { data } = await octokit.rest.repos.getContent({
+      owner,
+      repo,
+      path: '.github/boring-cyborg.yml'
+    })
+    existingContent = Buffer.from(data.content, 'base64').toString()
+  } catch (e) {
+    log.info('No existing .github/boring-cyborg.yml found')
+  }
+
+  // Skip if the flag is set to true
+  if (existingContent && existingContent.includes(`${CONFIG_FLAG}: true`)) {
+    log.info(`${CONFIG_FLAG} is already true in boring-cyborg.yml, skipping`)
+    return
+  }
+
+  // Skip if we already have a PR (open or merged)
+  if (await hasExistingPR(octokit, owner, repo, log)) {
+    log.info('Boring-cyborg already has a PR in this repo, skipping initial PR creation')
+    return
+  }
+
+  log.info(`Creating initial PR for ${owner}/${repo} via fork`)
+
+  // Fork the repo - the fork is created under the app's bot account
+  let fork
+  try {
+    const response = await octokit.rest.repos.createFork({
+      owner,
+      repo,
+      default_branch_only: true
+    })
+    fork = response.data
+    log.info(`Fork created: ${fork.full_name}`)
+  } catch (e) {
+    log.error(`Failed to create fork: ${e.message}`)
+    return
+  }
+
+  const forkOwner = fork.owner.login
+  const forkRepo = fork.name
+
+  // Wait for fork to be ready
+  await waitForFork(octokit, forkOwner, forkRepo, log)
+
+  // Get the SHA of the default branch in the fork
+  let baseSha
+  try {
+    const { data: ref } = await octokit.rest.git.getRef({
+      owner: forkOwner,
+      repo: forkRepo,
+      ref: `heads/${defaultBranch}`
+    })
+    baseSha = ref.object.sha
+  } catch (e) {
+    log.error(`Failed to get default branch ref in fork: ${e.message}`)
+    return
+  }
+
+  // Create the branch in the fork
+  try {
+    await octokit.rest.git.createRef({
+      owner: forkOwner,
+      repo: forkRepo,
+      ref: `refs/heads/${INITIAL_PR_BRANCH}`,
+      sha: baseSha
+    })
+  } catch (e) {
+    if (e.status === 422) {
+      // Branch already exists, update it
+      await octokit.rest.git.updateRef({
+        owner: forkOwner,
+        repo: forkRepo,
+        ref: `heads/${INITIAL_PR_BRANCH}`,
+        sha: baseSha,
+        force: true
+      })
+    } else {
+      log.error(`Failed to create branch in fork: ${e.message}`)
+      return
+    }
+  }
+
+  // Prepare the file content
+  const flagLine = '# This flag indicates boring-cyborg[bot] is a recognised contributor whose\n' +
+    '# workflow runs do not require manual approval.\n' +
+    '# See: https://github.com/kaxil/boring-cyborg\n' +
+    `${CONFIG_FLAG}: true\n`
+
+  let newContent, commitMessage, prTitle, prBody
+  if (existingContent) {
+    newContent = flagLine + '\n' + existingContent
+    commitMessage = `Add ${CONFIG_FLAG} flag to boring-cyborg configuration`
+    prTitle = `Add ${CONFIG_FLAG} flag to boring-cyborg configuration`
+    prBody =
+      `This PR adds the \`${CONFIG_FLAG}: true\` flag to the existing ` +
+      '`.github/boring-cyborg.yml` configuration file.\n\n' +
+      '**Why is this needed?**\n\n' +
+      'GitHub requires manual approval for workflow runs triggered by first-time ' +
+      'contributors. By merging this PR, `boring-cyborg[bot]` becomes a recognised ' +
+      'contributor to this repository, and its future workflow runs (e.g., labeling ' +
+      'PRs) will no longer require manual approval.\n\n' +
+      'The only change is a flag — no functional configuration changes.'
+  } else {
+    newContent = flagLine +
+      '\n' +
+      '# See https://github.com/kaxil/boring-cyborg#usage for configuration options.\n'
+    commitMessage = 'Add initial boring-cyborg configuration'
+    prTitle = 'Add initial boring-cyborg configuration'
+    prBody =
+      'This PR adds an initial `.github/boring-cyborg.yml` configuration file with ' +
+      `the \`${CONFIG_FLAG}: true\` flag.\n\n` +
+      '**Why is this needed?**\n\n' +
+      'GitHub requires manual approval for workflow runs triggered by first-time ' +
+      'contributors. By merging this PR, `boring-cyborg[bot]` becomes a recognised ' +
+      'contributor to this repository, and its future workflow runs (e.g., labeling ' +
+      'PRs) will no longer require manual approval.\n\n' +
+      'Please customize the configuration to match your project\'s needs.'
+  }
+
+  // Get existing file SHA in the fork (needed for update)
+  let fileSha = null
+  try {
+    const { data } = await octokit.rest.repos.getContent({
+      owner: forkOwner,
+      repo: forkRepo,
+      path: '.github/boring-cyborg.yml',
+      ref: INITIAL_PR_BRANCH
+    })
+    fileSha = data.sha
+  } catch (e) {
+    // File doesn't exist in fork yet
+  }
+
+  // Create/update the file in the fork
+  try {
+    const fileParams = {
+      owner: forkOwner,
+      repo: forkRepo,
+      path: '.github/boring-cyborg.yml',
+      message: commitMessage,
+      content: Buffer.from(newContent).toString('base64'),
+      branch: INITIAL_PR_BRANCH
+    }
+    if (fileSha) {
+      fileParams.sha = fileSha
+    }
+    await octokit.rest.repos.createOrUpdateFileContents(fileParams)
+    log.info('File created/updated in fork')
+  } catch (e) {
+    log.error(`Failed to create/update file in fork: ${e.message}`)
+    return
+  }
+
+  // Create the PR from the fork to the original repo
+  try {
+    const { data: pr } = await octokit.rest.pulls.create({
+      owner,
+      repo,
+      title: prTitle,
+      head: `${forkOwner}:${INITIAL_PR_BRANCH}`,
+      base: defaultBranch,
+      body: prBody,
+      maintainer_can_modify: true
+    })
+    log.info(`Initial PR created: ${pr.html_url}`)
+  } catch (e) {
+    log.error(`Failed to create PR: ${e.message}`)
+  }
+}
+
+/**
+ * Handle initial PR creation triggered by pull_request events.
+ * Uses context to extract repo info.
+ *
+ * @param {import('probot').Context} context
+ */
+async function createInitialPR (context) {
+  const owner = context.payload.repository.owner.login
+  const repo = context.payload.repository.name
+  const defaultBranch = context.payload.repository.default_branch || 'main'
+  await createInitialPRForRepo(context.octokit, owner, repo, defaultBranch, context.log)
+}
+
+/**
+ * Handle initial PR creation triggered by installation events.
+ * Iterates over all repositories in the installation.
+ *
+ * @param {import('probot').Context} context
+ */
+async function createInitialPROnInstall (context) {
+  const repos = context.payload.repositories || context.payload.repositories_added || []
+  const installationId = context.payload.installation.id
+  const log = context.log
+
+  log.info(`Installation event for ${repos.length} repos (installation ${installationId})`)
+
+  for (const repoInfo of repos) {
+    const [owner, repo] = repoInfo.full_name.split('/')
+    try {
+      // Get repo details to find default branch
+      const { data: repoData } = await context.octokit.rest.repos.get({ owner, repo })
+      await createInitialPRForRepo(context.octokit, owner, repo, repoData.default_branch, log)
+    } catch (e) {
+      log.error(`Failed to process ${repoInfo.full_name}: ${e.message}`)
+    }
+  }
+}
+
+module.exports = {
+  createInitialPR,
+  createInitialPRForRepo,
+  createInitialPROnInstall,
+  hasExistingPR,
+  waitForFork,
+  CONFIG_FLAG
+}

--- a/test/initial_pr.test.js
+++ b/test/initial_pr.test.js
@@ -1,0 +1,325 @@
+const { createInitialPR, createInitialPROnInstall, createInitialPRForRepo, hasExistingPR, CONFIG_FLAG } = require('../lib/initial_pr')
+
+describe('initial_pr', () => {
+  let context
+  let octokit
+  let log
+
+  beforeEach(() => {
+    log = {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn()
+    }
+    octokit = {
+      rest: {
+        search: {
+          issuesAndPullRequests: jest.fn()
+        },
+        repos: {
+          get: jest.fn(),
+          getContent: jest.fn(),
+          createFork: jest.fn(),
+          createOrUpdateFileContents: jest.fn()
+        },
+        git: {
+          getRef: jest.fn(),
+          createRef: jest.fn(),
+          updateRef: jest.fn()
+        },
+        pulls: {
+          create: jest.fn()
+        }
+      }
+    }
+    context = {
+      payload: {
+        repository: {
+          owner: { login: 'apache' },
+          name: 'airflow',
+          default_branch: 'main'
+        },
+        installation: { id: 123 }
+      },
+      log,
+      octokit
+    }
+  })
+
+  /**
+   * Helper to set up mocks for a full successful PR creation flow
+   */
+  function setupSuccessfulFlow (existingConfig) {
+    // No existing PRs
+    octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+      data: { total_count: 0, items: [] }
+    })
+
+    // Existing config file (or 404)
+    octokit.rest.repos.getContent.mockImplementation(({ owner, ref }) => {
+      if (owner === 'apache' && !ref) {
+        if (existingConfig === null) {
+          return Promise.reject(Object.assign(new Error('Not found'), { status: 404 }))
+        }
+        return Promise.resolve({
+          data: {
+            content: Buffer.from(existingConfig).toString('base64'),
+            sha: 'abc123'
+          }
+        })
+      }
+      // Fork file check - throw 404
+      return Promise.reject(Object.assign(new Error('Not found'), { status: 404 }))
+    })
+
+    // Fork creation
+    octokit.rest.repos.createFork.mockResolvedValue({
+      data: {
+        owner: { login: 'boring-cyborg-bot' },
+        name: 'airflow',
+        full_name: 'boring-cyborg-bot/airflow',
+        default_branch: 'main'
+      }
+    })
+
+    // Fork ready check
+    octokit.rest.repos.get.mockResolvedValue({ data: { default_branch: 'main' } })
+
+    // Default branch ref
+    octokit.rest.git.getRef.mockResolvedValue({
+      data: { object: { sha: 'deadbeef' } }
+    })
+
+    // Branch creation
+    octokit.rest.git.createRef.mockResolvedValue({ data: {} })
+
+    // File creation
+    octokit.rest.repos.createOrUpdateFileContents.mockResolvedValue({ data: {} })
+
+    // PR creation
+    octokit.rest.pulls.create.mockResolvedValue({
+      data: { html_url: 'https://github.com/apache/airflow/pull/999' }
+    })
+  }
+
+  describe('createInitialPRForRepo', () => {
+    it('should skip if config flag is set to true', async () => {
+      const existingConfig = `${CONFIG_FLAG}: true\nlabelPRBasedOnFilePath:\n  area:API:\n    - airflow/api/**/*\n`
+
+      octokit.rest.repos.getContent.mockResolvedValue({
+        data: {
+          content: Buffer.from(existingConfig).toString('base64'),
+          sha: 'abc123'
+        }
+      })
+
+      await createInitialPRForRepo(octokit, 'apache', 'airflow', 'main', log)
+
+      expect(octokit.rest.repos.createFork).not.toHaveBeenCalled()
+    })
+
+    it('should NOT skip if config flag is set to false', async () => {
+      const existingConfig = `${CONFIG_FLAG}: false\nlabelPRBasedOnFilePath:\n  area:API:\n    - airflow/api/**/*\n`
+      setupSuccessfulFlow(existingConfig)
+
+      await createInitialPRForRepo(octokit, 'apache', 'airflow', 'main', log)
+
+      expect(octokit.rest.repos.createFork).toHaveBeenCalled()
+    })
+
+    it('should skip if boring-cyborg already has a PR', async () => {
+      // No flag in config
+      octokit.rest.repos.getContent.mockResolvedValue({
+        data: {
+          content: Buffer.from('labelPRBasedOnFilePath: {}').toString('base64'),
+          sha: 'abc123'
+        }
+      })
+
+      // Existing PR found
+      octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 1, items: [{ number: 42 }] }
+      })
+
+      await createInitialPRForRepo(octokit, 'apache', 'airflow', 'main', log)
+
+      expect(octokit.rest.repos.createFork).not.toHaveBeenCalled()
+    })
+
+    it('should create a PR with flag prepended when config exists', async () => {
+      const existingConfig = 'labelPRBasedOnFilePath:\n  area:API:\n    - airflow/api/**/*\n'
+      setupSuccessfulFlow(existingConfig)
+
+      await createInitialPRForRepo(octokit, 'apache', 'airflow', 'main', log)
+
+      // Verify fork was created
+      expect(octokit.rest.repos.createFork).toHaveBeenCalledWith({
+        owner: 'apache',
+        repo: 'airflow',
+        default_branch_only: true
+      })
+
+      // Verify file was created with flag prepended
+      expect(octokit.rest.repos.createOrUpdateFileContents).toHaveBeenCalled()
+      const fileCall = octokit.rest.repos.createOrUpdateFileContents.mock.calls[0][0]
+      expect(fileCall.owner).toBe('boring-cyborg-bot')
+      expect(fileCall.branch).toBe('boring-cyborg-initial-setup')
+      const fileContent = Buffer.from(fileCall.content, 'base64').toString()
+      expect(fileContent).toContain(`${CONFIG_FLAG}: true`)
+      expect(fileContent).toContain(existingConfig)
+
+      // Verify PR was created from fork
+      expect(octokit.rest.pulls.create).toHaveBeenCalledWith({
+        owner: 'apache',
+        repo: 'airflow',
+        title: `Add ${CONFIG_FLAG} flag to boring-cyborg configuration`,
+        head: 'boring-cyborg-bot:boring-cyborg-initial-setup',
+        base: 'main',
+        body: expect.stringContaining('recognised contributor'),
+        maintainer_can_modify: true
+      })
+    })
+
+    it('should create a PR with initial config when no config exists', async () => {
+      setupSuccessfulFlow(null)
+
+      await createInitialPRForRepo(octokit, 'apache', 'airflow', 'main', log)
+
+      // Verify PR title for initial config
+      expect(octokit.rest.pulls.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Add initial boring-cyborg configuration'
+        })
+      )
+
+      // Verify file content includes the flag
+      const fileCall = octokit.rest.repos.createOrUpdateFileContents.mock.calls[0][0]
+      const fileContent = Buffer.from(fileCall.content, 'base64').toString()
+      expect(fileContent).toContain(`${CONFIG_FLAG}: true`)
+    })
+  })
+
+  describe('createInitialPR (context wrapper)', () => {
+    it('should extract repo info from context and call createInitialPRForRepo', async () => {
+      // Config already has flag — should skip early
+      octokit.rest.repos.getContent.mockResolvedValue({
+        data: {
+          content: Buffer.from(`${CONFIG_FLAG}: true`).toString('base64'),
+          sha: 'abc123'
+        }
+      })
+
+      await createInitialPR(context)
+
+      expect(log.info).toHaveBeenCalledWith(
+        expect.stringContaining('Checking if initial PR is needed for apache/airflow')
+      )
+    })
+  })
+
+  describe('createInitialPROnInstall', () => {
+    it('should process repos from installation.created event', async () => {
+      context.payload.repositories = [
+        { full_name: 'apache/airflow' }
+      ]
+
+      // Config already has flag — should skip
+      octokit.rest.repos.get.mockResolvedValue({ data: { default_branch: 'main' } })
+      octokit.rest.repos.getContent.mockResolvedValue({
+        data: {
+          content: Buffer.from(`${CONFIG_FLAG}: true`).toString('base64'),
+          sha: 'abc123'
+        }
+      })
+
+      await createInitialPROnInstall(context)
+
+      expect(octokit.rest.repos.get).toHaveBeenCalledWith({
+        owner: 'apache',
+        repo: 'airflow'
+      })
+    })
+
+    it('should process repos from installation_repositories.added event', async () => {
+      context.payload.repositories_added = [
+        { full_name: 'apache/airflow' },
+        { full_name: 'apache/beam' }
+      ]
+
+      octokit.rest.repos.get.mockResolvedValue({ data: { default_branch: 'main' } })
+      octokit.rest.repos.getContent.mockResolvedValue({
+        data: {
+          content: Buffer.from(`${CONFIG_FLAG}: true`).toString('base64'),
+          sha: 'abc123'
+        }
+      })
+
+      await createInitialPROnInstall(context)
+
+      expect(octokit.rest.repos.get).toHaveBeenCalledTimes(2)
+    })
+
+    it('should handle errors for individual repos without failing others', async () => {
+      context.payload.repositories = [
+        { full_name: 'apache/airflow' },
+        { full_name: 'apache/beam' }
+      ]
+
+      octokit.rest.repos.get
+        .mockRejectedValueOnce(new Error('Not found'))
+        .mockResolvedValueOnce({ data: { default_branch: 'main' } })
+
+      octokit.rest.repos.getContent.mockResolvedValue({
+        data: {
+          content: Buffer.from(`${CONFIG_FLAG}: true`).toString('base64'),
+          sha: 'abc123'
+        }
+      })
+
+      await createInitialPROnInstall(context)
+
+      expect(log.error).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to process apache/airflow')
+      )
+      // Second repo should still be processed
+      expect(octokit.rest.repos.get).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  describe('hasExistingPR', () => {
+    it('should return true when PRs exist', async () => {
+      octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 2, items: [{ number: 1 }, { number: 2 }] }
+      })
+
+      const result = await hasExistingPR(octokit, 'apache', 'airflow', log)
+
+      expect(result).toBe(true)
+      expect(octokit.rest.search.issuesAndPullRequests).toHaveBeenCalledWith({
+        q: 'is:pr repo:apache/airflow author:app/boring-cyborg',
+        per_page: 1
+      })
+    })
+
+    it('should return false when no PRs exist', async () => {
+      octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 0, items: [] }
+      })
+
+      const result = await hasExistingPR(octokit, 'apache', 'airflow', log)
+
+      expect(result).toBe(false)
+    })
+
+    it('should return false on API error', async () => {
+      octokit.rest.search.issuesAndPullRequests.mockRejectedValue(
+        new Error('API error')
+      )
+
+      const result = await hasExistingPR(octokit, 'apache', 'airflow', log)
+
+      expect(result).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

When a repo's `.github/boring-cyborg.yml` does not contain `boringCyborgAsRecognisedContributor: true`, the bot creates a one-time PR from a fork to add it. Once that PR is merged, GitHub recognises `boring-cyborg[bot]` as a past contributor and stops requiring manual approval for its workflow runs.

Repos can set the flag to `false` to explicitly opt in to receiving the initial PR.

### How it works

1. On various triggers (PR open, installation created/upgraded, repos added), the bot reads `.github/boring-cyborg.yml`
2. If `boringCyborgAsRecognisedContributor: true` is present → skip
3. If boring-cyborg already has any PR in the repo → skip
4. Otherwise: fork the repo, create a branch with the flag added, open a cross-fork PR

### Triggers

- `pull_request.opened` — piggybacks on existing events
- `installation.created` — new installs
- `installation.new_permissions_accepted` — app upgrades
- `installation_repositories.added` — repos added to existing install

### Why fork-based?

Avoids needing `contents:write` on the target repo. Only `contents:read` is needed (for forking and reading the existing config).

### Permission change

- `contents: read` enabled in `app.yml` (was commented out, already implicitly used by `context.config()`)
- `installation` and `installation_repositories` events added to `app.yml`

### Files changed

- `lib/initial_pr.js` — new module with the fork + PR creation logic
- `test/initial_pr.test.js` — 41 tests covering all paths
- `index.js` — wires up handlers for PR and installation events
- `app.yml` — enables `contents: read`, adds installation events