### PR TITLE
Allow per-rule targetBranchFilter in labeler, reviewer, and issuelink

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,12 +41,23 @@ This is helpful when you desire the changes to be applied sequentially, for exam
 # Patterns are matched as regular expressions. Use ^ and $ anchors for exact
 # branch name matching (e.g. ^main$ instead of just main, which would also
 # match branches like "my-maintainer-branch").
+#
+# Individual rules inside `labelPRBasedOnFilePath`, `addReviewerBasedOnLabel.labels`,
+# and `insertIssueLinkInPrDescription.matchers` can each carry their own
+# `targetBranchFilter`. The top-level filter gates the feature entirely;
+# the per-rule filter then gates the individual rule. Rules without a filter
+# run on every branch that passes the top-level gate.
 targetBranchFilter:
   - ^main$
   - ^release/.*$
 
 ##### Labeler ##########################################################################################################
 # Enable "labeler" for your PR that would add labels to PRs based on the paths that are modified in the PR.
+#
+# Each label rule can be either:
+#   - a list of glob patterns (applies on every branch), or
+#   - an object with `paths` and an optional `targetBranchFilter` that limits the label
+#     to PRs whose base ref matches one of the patterns.
 labelPRBasedOnFilePath:
   # Add 'label1' to any changes within 'example' folder or any subfolders
   label1:
@@ -65,6 +76,13 @@ labelPRBasedOnFilePath:
   test:
     - src/**/*.spec.js
 
+  # Only apply 'needs-backport' on release branches
+  needs-backport:
+    paths:
+      - src/**/*
+    targetBranchFilter:
+      - ^release/.*$
+
 # Various Flags to control behaviour of the "Labeler"
 labelerFlags:
   # If this flag is changed to 'false', labels would only be added when the PR is first created and not when existing
@@ -74,6 +92,11 @@ labelerFlags:
 
 ##### Reviewer #########################################################################################################
 # Enable "Reviewer" for your PR that would add reviewers to PRs based on the lables that exist on the PR. You have the option to set a default reviewer that gets added to every PR, or you can omit that config variable to skip it.
+#
+# Each entry under `labels` can be either:
+#   - a list of reviewer logins (applies on every branch), or
+#   - an object with `reviewers` and an optional `targetBranchFilter` that limits
+#     the assignment to PRs whose base ref matches one of the patterns.
 addReviewerBasedOnLabel:
   # add list of reviewers to add by default to all PRs
   defaultReviewers:
@@ -85,6 +108,12 @@ addReviewerBasedOnLabel:
       - jordan-violet-sp
     label2:
       - kaxil
+    # Only request release managers on PRs targeting release branches
+    label3:
+      reviewers:
+        - release-manager
+      targetBranchFilter:
+        - ^release/.*$
 
 ##### Greetings ########################################################################################################
 # Comment to be posted to welcome users when they open their first PR
@@ -101,6 +130,10 @@ firstIssueWelcomeComment: >
 
 ###### IssueLink Adder #################################################################################################
 # Insert Issue (Jira/Github etc) link in PR description based on the Issue ID in PR title.
+#
+# Each matcher under `matchers` may declare an optional `targetBranchFilter` so that
+# the matcher only applies on matching base branches. The first matcher that is
+# both enabled for the base ref and whose regex matches the PR title is used.
 insertIssueLinkInPrDescription:
    # specify the placeholder for the issue link that should be present in the description
   descriptionIssuePlaceholderRegexp: "^Issue link: (.*)$"
@@ -117,6 +150,11 @@ insertIssueLinkInPrDescription:
     docOnlyIssueMatch:
       titleIssueIdRegexp: \[(AIRFLOW-X{4})\]
       descriptionIssueLink: "`Document only change, no JIRA issue`"
+    # Only used on release branches
+    releaseIssueMatch:
+      titleIssueIdRegexp: \[(AIRFLOW-[0-9]{4})\]
+      descriptionIssueLink: "[${1}](https://issues.apache.org/jira/browse/${1}/) (release)"
+      targetBranchFilter: ^release/.*$
 
 ###### Title Validator #################################################################################################
 # Verifies if commit/PR titles match the regexp specified

--- a/lib/issuelink.js
+++ b/lib/issuelink.js
@@ -1,3 +1,5 @@
+const utils = require('./utils')
+
 /**
  * Modifies the description of the PR and updates issue link with the
  * Issue id present in issue title..
@@ -36,6 +38,10 @@ async function insertIssueLinkInPrDescription (context, config) {
 
     for (const matcher in insertIssueLinkInPrDescription.matchers) {
       const matcherObject = insertIssueLinkInPrDescription.matchers[matcher]
+      if (!utils.matchesBranchFilter(context, matcherObject.targetBranchFilter)) {
+        context.log.debug(`Skipping matcher "${matcher}": PR base ref does not match matcher's targetBranchFilter`)
+        continue
+      }
       const issueIdRegexp = new RegExp(matcherObject.titleIssueIdRegexp)
       const matchedIssueIdArray = issueIdRegexp.exec(pr.title)
       if (matchedIssueIdArray == null) {

--- a/lib/labeler.js
+++ b/lib/labeler.js
@@ -1,4 +1,20 @@
 const ignore = require('ignore')
+const utils = require('./utils')
+
+/**
+ * Normalize a single label rule into `{ paths, targetBranchFilter }`.
+ * Accepts either the legacy array-of-paths form or an object form with
+ * `paths` and optional `targetBranchFilter`.
+ */
+function _parseRule (rule) {
+  if (Array.isArray(rule)) {
+    return { paths: rule, targetBranchFilter: undefined }
+  }
+  if (rule && typeof rule === 'object') {
+    return { paths: rule.paths, targetBranchFilter: rule.targetBranchFilter }
+  }
+  return { paths: undefined, targetBranchFilter: undefined }
+}
 
 /**
  * Add labels based on the path of the file that are modified in the PR
@@ -45,8 +61,19 @@ async function addLabelsOnPr (context, config) {
     for (const label in addLabelsOnPrConfig) {
       allLabels.add(label)
 
-      context.log.debug(`Looking for files: label="${label}", pattern="${JSON.stringify(addLabelsOnPrConfig[label])}")`)
-      const matcher = ignore().add(addLabelsOnPrConfig[label])
+      const { paths, targetBranchFilter } = _parseRule(addLabelsOnPrConfig[label])
+      if (!paths) {
+        context.log.warn(`Skipping label "${label}": no paths configured`)
+        continue
+      }
+
+      if (!utils.matchesBranchFilter(context, targetBranchFilter)) {
+        context.log.info(`Skipping label "${label}": PR base ref does not match rule's targetBranchFilter`)
+        continue
+      }
+
+      context.log.debug(`Looking for files: label="${label}", pattern="${JSON.stringify(paths)}")`)
+      const matcher = ignore().add(paths)
 
       if (modifiedFiles.find(file => matcher.ignores(file))) {
         context.log.info(`Found files matching conditions, applying label: "${label}"`)

--- a/lib/reviewer.js
+++ b/lib/reviewer.js
@@ -1,3 +1,20 @@
+const utils = require('./utils')
+
+/**
+ * Normalize a single label rule into `{ reviewers, targetBranchFilter }`.
+ * Accepts either the legacy array-of-reviewers form or an object form with
+ * `reviewers` and optional `targetBranchFilter`.
+ */
+function _parseRule (rule) {
+  if (Array.isArray(rule)) {
+    return { reviewers: rule, targetBranchFilter: undefined }
+  }
+  if (rule && typeof rule === 'object') {
+    return { reviewers: rule.reviewers, targetBranchFilter: rule.targetBranchFilter }
+  }
+  return { reviewers: undefined, targetBranchFilter: undefined }
+}
+
 /**
  * Assign reviewers based on the labels that are assigned in the PR
  * @param {import('probot').Context} context
@@ -51,8 +68,16 @@ async function addReviewersOnPr (context, config) {
           context.log.info(`Label: ${label}. Exists in the PR: true. Exists in config: ${reviewerMap.has(label)}`)
 
           if (reviewerMap.has(label)) {
-            const reviewersForLabel = reviewerMap.get(label)
-            reviewersForLabel.forEach(reviewer => {
+            const { reviewers, targetBranchFilter } = _parseRule(reviewerMap.get(label))
+            if (!reviewers) {
+              context.log.warn(`Skipping label "${label}": no reviewers configured`)
+              return
+            }
+            if (!utils.matchesBranchFilter(context, targetBranchFilter)) {
+              context.log.info(`Skipping reviewers for label "${label}": PR base ref does not match rule's targetBranchFilter`)
+              return
+            }
+            reviewers.forEach(reviewer => {
               reviewersToAssign.add(reviewer)
             })
           }

--- a/lib/reviewer.js
+++ b/lib/reviewer.js
@@ -1,7 +1,7 @@
 const utils = require('./utils')
 
 /**
- * Normalize a single label rule into `{ reviewers, targetBranchFilter }`.
+ * Normalize a single reviewer rule into `{ reviewers, targetBranchFilter }`.
  * Accepts either the legacy array-of-reviewers form or an object form with
  * `reviewers` and optional `targetBranchFilter`.
  */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,20 +9,21 @@ module.exports.getConfig = function (context) {
 }
 
 /**
- * Check if the PR associated with the current context should be processed,
- * given the optional `targetBranchFilter` config entry.
+ * Check whether the PR base ref matches a `targetBranchFilter` value.
  *
- * `targetBranchFilter` may be a single regex string or an array of regex strings.
- * If any pattern matches the PR base ref the PR is processed. If the config key
- * is missing, all PRs are processed. Events without a pull_request payload (e.g.
- * plain issue events) are never filtered out by this helper.
+ * The filter may be a single regex string or an array of regex strings. A
+ * missing, null, empty-string, or empty-array filter is treated as unset and
+ * matches everything. Events without a pull_request payload (e.g. plain issue
+ * events) are never filtered out — this helper only gates PR work.
+ *
+ * Unsafe or invalid regex patterns are logged and skipped; if no valid pattern
+ * matches, the function returns false.
  *
  * @param {import('probot').Context} context
- * @param {object} config
+ * @param {string|string[]|undefined|null} filter
  * @returns {boolean}
  */
-module.exports.shouldProcessPr = function (context, config) {
-  const filter = config && config.targetBranchFilter
+module.exports.matchesBranchFilter = function (context, filter) {
   if (
     filter === undefined ||
     filter === null ||
@@ -60,6 +61,24 @@ module.exports.shouldProcessPr = function (context, config) {
     }
   }
 
+  return false
+}
+
+/**
+ * Check if the PR associated with the current context should be processed,
+ * given the optional top-level `targetBranchFilter` config entry. Logs a
+ * skip message when the PR is filtered out.
+ *
+ * @param {import('probot').Context} context
+ * @param {object} config
+ * @returns {boolean}
+ */
+module.exports.shouldProcessPr = function (context, config) {
+  const filter = config && config.targetBranchFilter
+  if (module.exports.matchesBranchFilter(context, filter)) {
+    return true
+  }
+  const baseRef = context.payload.pull_request.base.ref
   context.log.info(`Skipping PR: base ref "${baseRef}" does not match targetBranchFilter`)
   return false
 }

--- a/test/issuelink.test.js
+++ b/test/issuelink.test.js
@@ -1,0 +1,104 @@
+/* eslint-disable no-template-curly-in-string */
+const { insertIssueLinkInPrDescription } = require('../lib/issuelink')
+
+describe('issuelink', () => {
+  let context
+
+  beforeEach(() => {
+    context = {
+      event: 'pull_request',
+      payload: {
+        action: 'opened',
+        pull_request: { number: 1, base: { ref: 'main' } }
+      },
+      log: {
+        info: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn()
+      },
+      octokit: {
+        pulls: { get: jest.fn() },
+        issues: { update: jest.fn() }
+      },
+      issue: jest.fn((params) => ({ owner: 'owner', repo: 'repo', issue_number: 1, ...params })),
+      repo: jest.fn((params) => ({ owner: 'owner', repo: 'repo', ...params }))
+    }
+  })
+
+  const baseConfig = (matchers) => ({
+    insertIssueLinkInPrDescription: {
+      descriptionIssuePlaceholderRegexp: '^Issue link: (.*)$',
+      matchers
+    }
+  })
+
+  const prWithTitleAndBody = (title, body) => ({
+    data: {
+      url: 'https://api.github.com/repos/owner/repo/pulls/1',
+      title,
+      body
+    }
+  })
+
+  it('uses the first matching matcher when no per-matcher filter is set', async () => {
+    context.octokit.pulls.get.mockResolvedValue(
+      prWithTitleAndBody('[AIRFLOW-1234] Fix X', 'Issue link: PLACEHOLDER')
+    )
+
+    await insertIssueLinkInPrDescription(context, baseConfig({
+      jiraIssueMatch: {
+        titleIssueIdRegexp: '\\[(AIRFLOW-[0-9]{4})\\]',
+        descriptionIssueLink: 'LINK-${1}'
+      }
+    }))
+
+    expect(context.octokit.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Issue link: LINK-AIRFLOW-1234' })
+    )
+  })
+
+  it('skips a matcher whose targetBranchFilter does not match the base ref', async () => {
+    context.octokit.pulls.get.mockResolvedValue(
+      prWithTitleAndBody('[AIRFLOW-1234] Fix X', 'Issue link: PLACEHOLDER')
+    )
+
+    await insertIssueLinkInPrDescription(context, baseConfig({
+      releaseOnly: {
+        titleIssueIdRegexp: '\\[(AIRFLOW-[0-9]{4})\\]',
+        descriptionIssueLink: 'RELEASE-${1}',
+        targetBranchFilter: '^release/.*$'
+      },
+      fallback: {
+        titleIssueIdRegexp: '\\[(AIRFLOW-[0-9]{4})\\]',
+        descriptionIssueLink: 'MAIN-${1}'
+      }
+    }))
+
+    expect(context.octokit.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Issue link: MAIN-AIRFLOW-1234' })
+    )
+  })
+
+  it('uses a matcher whose targetBranchFilter matches the base ref', async () => {
+    context.payload.pull_request.base.ref = 'release/1.2'
+    context.octokit.pulls.get.mockResolvedValue(
+      prWithTitleAndBody('[AIRFLOW-1234] Fix X', 'Issue link: PLACEHOLDER')
+    )
+
+    await insertIssueLinkInPrDescription(context, baseConfig({
+      releaseOnly: {
+        titleIssueIdRegexp: '\\[(AIRFLOW-[0-9]{4})\\]',
+        descriptionIssueLink: 'RELEASE-${1}',
+        targetBranchFilter: '^release/.*$'
+      },
+      fallback: {
+        titleIssueIdRegexp: '\\[(AIRFLOW-[0-9]{4})\\]',
+        descriptionIssueLink: 'MAIN-${1}'
+      }
+    }))
+
+    expect(context.octokit.issues.update).toHaveBeenCalledWith(
+      expect.objectContaining({ body: 'Issue link: RELEASE-AIRFLOW-1234' })
+    )
+  })
+})

--- a/test/labeler.test.js
+++ b/test/labeler.test.js
@@ -9,7 +9,8 @@ describe('labeler', () => {
       payload: {
         action: 'opened',
         pull_request: {
-          number: 1
+          number: 1,
+          base: { ref: 'main' }
         }
       },
       log: {
@@ -139,6 +140,91 @@ describe('labeler', () => {
       await addLabelsOnPr(context, config)
 
       expect(context.octokit.pulls.get).not.toHaveBeenCalled()
+      expect(context.octokit.issues.addLabels).not.toHaveBeenCalled()
+    })
+
+    it('should accept the object rule form with paths + targetBranchFilter', async () => {
+      const config = {
+        labelPRBasedOnFilePath: {
+          frontend: {
+            paths: ['src/frontend/**/*'],
+            targetBranchFilter: '^main$'
+          }
+        }
+      }
+
+      context.octokit.pulls.get.mockResolvedValue({
+        data: {
+          url: 'https://api.github.com/repos/owner/repo/pulls/1',
+          labels: []
+        }
+      })
+      context.octokit.pulls.listFiles.mockResolvedValue({
+        data: [{ filename: 'src/frontend/component.js' }]
+      })
+
+      await addLabelsOnPr(context, config)
+
+      expect(context.octokit.issues.addLabels).toHaveBeenCalledWith({
+        owner: 'owner',
+        repo: 'repo',
+        pull_number: 1,
+        labels: ['frontend']
+      })
+    })
+
+    it('should skip a label whose rule-level targetBranchFilter does not match', async () => {
+      const config = {
+        labelPRBasedOnFilePath: {
+          frontend: {
+            paths: ['src/frontend/**/*'],
+            targetBranchFilter: '^release/.*$'
+          },
+          backend: ['src/backend/**/*']
+        }
+      }
+
+      context.octokit.pulls.get.mockResolvedValue({
+        data: {
+          url: 'https://api.github.com/repos/owner/repo/pulls/1',
+          labels: []
+        }
+      })
+      context.octokit.pulls.listFiles.mockResolvedValue({
+        data: [
+          { filename: 'src/frontend/component.js' },
+          { filename: 'src/backend/api.js' }
+        ]
+      })
+
+      await addLabelsOnPr(context, config)
+
+      expect(context.octokit.issues.addLabels).toHaveBeenCalledWith({
+        owner: 'owner',
+        repo: 'repo',
+        pull_number: 1,
+        labels: ['backend']
+      })
+    })
+
+    it('should warn and skip a rule with no paths configured', async () => {
+      const config = {
+        labelPRBasedOnFilePath: {
+          broken: { targetBranchFilter: '^main$' }
+        }
+      }
+
+      context.octokit.pulls.get.mockResolvedValue({
+        data: {
+          url: 'https://api.github.com/repos/owner/repo/pulls/1',
+          labels: []
+        }
+      })
+      context.octokit.pulls.listFiles.mockResolvedValue({ data: [] })
+
+      await addLabelsOnPr(context, config)
+
+      expect(context.log.warn).toHaveBeenCalled()
       expect(context.octokit.issues.addLabels).not.toHaveBeenCalled()
     })
   })

--- a/test/reviewer.test.js
+++ b/test/reviewer.test.js
@@ -7,7 +7,8 @@ describe('reviewer', () => {
     context = {
       event: 'pull_request',
       payload: {
-        action: 'labeled'
+        action: 'labeled',
+        pull_request: { number: 1, base: { ref: 'main' } }
       },
       log: {
         info: jest.fn(),
@@ -116,6 +117,96 @@ describe('reviewer', () => {
       await addReviewersOnPr(context, config)
 
       expect(context.octokit.pulls.get).not.toHaveBeenCalled()
+      expect(context.octokit.pulls.createReviewRequest).not.toHaveBeenCalled()
+    })
+
+    it('should accept the object rule form with reviewers + targetBranchFilter', async () => {
+      const config = {
+        addReviewerBasedOnLabel: {
+          labels: {
+            frontend: {
+              reviewers: ['frontend-reviewer'],
+              targetBranchFilter: '^main$'
+            }
+          }
+        }
+      }
+
+      context.octokit.pulls.get.mockResolvedValue({
+        data: {
+          url: 'https://api.github.com/repos/owner/repo/pulls/1',
+          number: 1,
+          user: { login: 'author' },
+          labels: [{ name: 'frontend' }],
+          requested_reviewers: []
+        }
+      })
+
+      await addReviewersOnPr(context, config)
+
+      expect(context.octokit.pulls.createReviewRequest).toHaveBeenCalledWith({
+        owner: 'owner',
+        repo: 'repo',
+        pull_number: 1,
+        reviewers: ['frontend-reviewer']
+      })
+    })
+
+    it('should skip reviewers for a label whose filter does not match', async () => {
+      const config = {
+        addReviewerBasedOnLabel: {
+          labels: {
+            frontend: {
+              reviewers: ['frontend-reviewer'],
+              targetBranchFilter: '^release/.*$'
+            },
+            backend: ['backend-reviewer']
+          }
+        }
+      }
+
+      context.octokit.pulls.get.mockResolvedValue({
+        data: {
+          url: 'https://api.github.com/repos/owner/repo/pulls/1',
+          number: 1,
+          user: { login: 'author' },
+          labels: [{ name: 'frontend' }, { name: 'backend' }],
+          requested_reviewers: []
+        }
+      })
+
+      await addReviewersOnPr(context, config)
+
+      expect(context.octokit.pulls.createReviewRequest).toHaveBeenCalledWith({
+        owner: 'owner',
+        repo: 'repo',
+        pull_number: 1,
+        reviewers: ['backend-reviewer']
+      })
+    })
+
+    it('should warn and skip a rule with no reviewers configured', async () => {
+      const config = {
+        addReviewerBasedOnLabel: {
+          labels: {
+            frontend: { targetBranchFilter: '^main$' }
+          }
+        }
+      }
+
+      context.octokit.pulls.get.mockResolvedValue({
+        data: {
+          url: 'https://api.github.com/repos/owner/repo/pulls/1',
+          number: 1,
+          user: { login: 'author' },
+          labels: [{ name: 'frontend' }],
+          requested_reviewers: []
+        }
+      })
+
+      await addReviewersOnPr(context, config)
+
+      expect(context.log.warn).toHaveBeenCalled()
       expect(context.octokit.pulls.createReviewRequest).not.toHaveBeenCalled()
     })
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -93,4 +93,48 @@ describe('utils', () => {
       expect(ctx.log.warn).toHaveBeenCalled()
     })
   })
+
+  describe('matchesBranchFilter', () => {
+    it('returns true for an unset filter (undefined/null/empty)', () => {
+      const ctx = makeContext('main')
+      expect(utils.matchesBranchFilter(ctx, undefined)).toBe(true)
+      expect(utils.matchesBranchFilter(ctx, null)).toBe(true)
+      expect(utils.matchesBranchFilter(ctx, '')).toBe(true)
+      expect(utils.matchesBranchFilter(ctx, [])).toBe(true)
+    })
+
+    it('returns true when payload has no pull_request', () => {
+      expect(utils.matchesBranchFilter(makeContext(undefined), '^main$')).toBe(true)
+    })
+
+    it('matches against a single string pattern', () => {
+      expect(utils.matchesBranchFilter(makeContext('main'), '^main$')).toBe(true)
+      expect(utils.matchesBranchFilter(makeContext('dev'), '^main$')).toBe(false)
+    })
+
+    it('matches against an array (any-match passes)', () => {
+      const filter = ['^main$', '^release/.*$']
+      expect(utils.matchesBranchFilter(makeContext('main'), filter)).toBe(true)
+      expect(utils.matchesBranchFilter(makeContext('release/1.2'), filter)).toBe(true)
+      expect(utils.matchesBranchFilter(makeContext('feature/x'), filter)).toBe(false)
+    })
+
+    it('skips invalid regex patterns and logs a warning', () => {
+      const ctx = makeContext('main')
+      expect(utils.matchesBranchFilter(ctx, ['[unclosed'])).toBe(false)
+      expect(ctx.log.warn).toHaveBeenCalled()
+    })
+
+    it('skips unsafe regex patterns and logs a warning', () => {
+      const ctx = makeContext('main')
+      expect(utils.matchesBranchFilter(ctx, ['^(a+)+$'])).toBe(false)
+      expect(ctx.log.warn).toHaveBeenCalled()
+    })
+
+    it('does NOT log a skip message on mismatch (caller decides)', () => {
+      const ctx = makeContext('dev')
+      expect(utils.matchesBranchFilter(ctx, '^main$')).toBe(false)
+      expect(ctx.log.info).not.toHaveBeenCalled()
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Follow-up on #111. Extends `targetBranchFilter` so individual rules inside features with multi-entry configs can declare their own branch filter, alongside the existing top-level one.

- `labelPRBasedOnFilePath.<label>` now accepts either the legacy `[paths]` array or `{ paths, targetBranchFilter }`.
- `addReviewerBasedOnLabel.labels.<label>` now accepts either `[reviewers]` or `{ reviewers, targetBranchFilter }`.
- `insertIssueLinkInPrDescription.matchers.<name>` may carry an optional `targetBranchFilter` — non-matching matchers are skipped so another matcher can still win.
- Top-level filter gates whole features; per-rule filter gates individual rules. Rules without a filter run on every branch that survives the top-level gate. Legacy array shapes keep working unchanged.
- Shared regex / `safe-regex2` logic extracted into `utils.matchesBranchFilter` so PR-gate and rule-gate callers validate and log consistently.

README updated with examples for each feature.

## Test plan

- [x] `npm test` (jest + standard) — 55 tests pass, lint clean
- [x] `matchesBranchFilter` covered directly in `test/utils.test.js`
- [x] Labeler: legacy array + new object form + rule-level filter skip + missing-`paths` warning
- [x] Reviewer: legacy array + new object form + rule-level filter skip + missing-`reviewers` warning
- [x] Issuelink (new test file): matcher with filter runs on matching base, is skipped on non-matching base, and falls through to a fallback matcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)