### PR TITLE
Fix bugs and improve test coverage (55 → 84 tests)

### DIFF
--- a/lib/issuelink.js
+++ b/lib/issuelink.js
@@ -67,7 +67,7 @@ async function insertIssueLinkInPrDescription (context, config) {
         linkString +
         pr.body.substr(placeholderPosition + linkPlaceholderPosition + linkPlaceholderLength)
       context.log.debug(`Updating PR: ${pr.html_url} with new body: ${newBody}`)
-      context.octokit.issues.update(context.issue({ body: newBody }))
+      await context.octokit.issues.update(context.issue({ body: newBody }))
       break
     }
   } else {

--- a/lib/up_to_date_checker.js
+++ b/lib/up_to_date_checker.js
@@ -33,8 +33,14 @@ async function checkUpToDate (context, config) {
       if (!(targetBranchKey in config[configKey])) {
         filePatterns = config[configKey]
       } else {
-        context.log.debug('No file pattern defined')
+        context.log.debug('No file patterns configured, skipping up-to-date check')
+        return
       }
+    }
+
+    if (!filePatterns || (Array.isArray(filePatterns) && filePatterns.length === 0)) {
+      context.log.debug('No file patterns configured, skipping up-to-date check')
+      return
     }
 
     // Get files in the PR

--- a/test/greetings.test.js
+++ b/test/greetings.test.js
@@ -1,46 +1,11 @@
 const { commentOnfirstPR, commentOnfirstPRMerge, commentOnfirstIssue } = require('../lib/greetings')
+const { createMockContext } = require('./helpers')
 
 describe('greetings', () => {
   let context
 
   beforeEach(() => {
-    context = {
-      payload: {
-        pull_request: {
-          user: { login: 'testuser' },
-          number: 1,
-          html_url: 'https://github.com/owner/repo/pull/1',
-          merged: false,
-          created_at: '2024-01-01T00:00:00Z',
-          merged_at: '2024-01-02T00:00:00Z'
-        },
-        repository: {
-          full_name: 'owner/repo'
-        },
-        issue: {
-          user: { login: 'testuser' },
-          number: 1,
-          html_url: 'https://github.com/owner/repo/issues/1',
-          created_at: '2024-01-01T00:00:00Z'
-        }
-      },
-      log: {
-        info: jest.fn(),
-        debug: jest.fn(),
-        warn: jest.fn()
-      },
-      octokit: {
-        rest: {
-          search: {
-            issuesAndPullRequests: jest.fn()
-          }
-        },
-        issues: {
-          createComment: jest.fn()
-        }
-      },
-      issue: jest.fn((obj = {}) => ({ owner: 'owner', repo: 'repo', issue_number: 1, ...obj }))
-    }
+    context = createMockContext()
   })
 
   describe('commentOnfirstPR', () => {
@@ -83,6 +48,56 @@ describe('greetings', () => {
       await commentOnfirstPR(context, config)
 
       expect(context.octokit.issues.createComment).not.toHaveBeenCalled()
+    })
+
+    it('should construct the correct search query for first-time check', async () => {
+      const config = {
+        firstPRWelcomeComment: 'Welcome!'
+      }
+
+      context.octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 0, items: [] }
+      })
+
+      await commentOnfirstPR(context, config)
+
+      const searchCall = context.octokit.rest.search.issuesAndPullRequests.mock.calls[0][0]
+      expect(searchCall.q).toContain('is:pr')
+      expect(searchCall.q).toContain('author:testuser')
+      expect(searchCall.q).toContain('repo:owner/repo')
+      expect(searchCall.q).toContain('created:<2024-01-01T00:00:00Z')
+      expect(searchCall.per_page).toBe(1)
+    })
+
+    it('should swallow 404 errors from createComment', async () => {
+      const config = {
+        firstPRWelcomeComment: 'Welcome!'
+      }
+
+      context.octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 0, items: [] }
+      })
+      const notFoundError = new Error('Not Found')
+      notFoundError.code = 404
+      context.octokit.issues.createComment.mockRejectedValue(notFoundError)
+
+      // 404 should be swallowed (PR deleted between webhook and handler)
+      await expect(commentOnfirstPR(context, config)).resolves.not.toThrow()
+    })
+
+    it('should re-throw non-404 errors from createComment', async () => {
+      const config = {
+        firstPRWelcomeComment: 'Welcome!'
+      }
+
+      context.octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 0, items: [] }
+      })
+      const serverError = new Error('Internal Server Error')
+      serverError.code = 500
+      context.octokit.issues.createComment.mockRejectedValue(serverError)
+
+      await expect(commentOnfirstPR(context, config)).rejects.toThrow('Internal Server Error')
     })
 
     it('should not add comment if config not present', async () => {
@@ -133,6 +148,42 @@ describe('greetings', () => {
       expect(context.octokit.rest.search.issuesAndPullRequests).not.toHaveBeenCalled()
       expect(context.octokit.issues.createComment).not.toHaveBeenCalled()
     })
+
+    it('should construct the correct search query for first-merged check', async () => {
+      const config = { firstPRMergeComment: 'Congrats!' }
+      context.payload.pull_request.merged = true
+
+      context.octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 0, items: [] }
+      })
+
+      await commentOnfirstPRMerge(context, config)
+
+      const searchCall = context.octokit.rest.search.issuesAndPullRequests.mock.calls[0][0]
+      expect(searchCall.q).toContain('is:pr')
+      expect(searchCall.q).toContain('is:merged')
+      expect(searchCall.q).toContain('author:testuser')
+      expect(searchCall.q).toContain('repo:owner/repo')
+    })
+
+    it('should swallow 404 but re-throw 500 from createComment on merge', async () => {
+      const config = { firstPRMergeComment: 'Congrats!' }
+      context.payload.pull_request.merged = true
+
+      context.octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 0, items: [] }
+      })
+
+      const notFoundError = new Error('Not Found')
+      notFoundError.code = 404
+      context.octokit.issues.createComment.mockRejectedValue(notFoundError)
+      await expect(commentOnfirstPRMerge(context, config)).resolves.not.toThrow()
+
+      const serverError = new Error('Server Error')
+      serverError.code = 500
+      context.octokit.issues.createComment.mockRejectedValue(serverError)
+      await expect(commentOnfirstPRMerge(context, config)).rejects.toThrow('Server Error')
+    })
   })
 
   describe('commentOnfirstIssue', () => {
@@ -158,6 +209,39 @@ describe('greetings', () => {
         issue_number: 1,
         body: 'Welcome to your first issue!'
       })
+    })
+
+    it('should construct the correct search query for first-issue check', async () => {
+      const config = { firstIssueWelcomeComment: 'Welcome!' }
+
+      context.octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 0, items: [] }
+      })
+
+      await commentOnfirstIssue(context, config)
+
+      const searchCall = context.octokit.rest.search.issuesAndPullRequests.mock.calls[0][0]
+      expect(searchCall.q).toContain('is:issue')
+      expect(searchCall.q).toContain('author:testuser')
+      expect(searchCall.q).toContain('repo:owner/repo')
+    })
+
+    it('should swallow 404 but re-throw 500 from createComment on issue', async () => {
+      const config = { firstIssueWelcomeComment: 'Welcome!' }
+
+      context.octokit.rest.search.issuesAndPullRequests.mockResolvedValue({
+        data: { total_count: 0, items: [] }
+      })
+
+      const notFoundError = new Error('Not Found')
+      notFoundError.code = 404
+      context.octokit.issues.createComment.mockRejectedValue(notFoundError)
+      await expect(commentOnfirstIssue(context, config)).resolves.not.toThrow()
+
+      const serverError = new Error('Server Error')
+      serverError.code = 500
+      context.octokit.issues.createComment.mockRejectedValue(serverError)
+      await expect(commentOnfirstIssue(context, config)).rejects.toThrow('Server Error')
     })
 
     it('should not add comment if not first issue', async () => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,88 @@
+/**
+ * Shared test helpers for boring-cyborg tests.
+ *
+ * Provides a consistent mock context factory so all test files use the same
+ * shape and avoid subtle inconsistencies (e.g. context.issue accepting params
+ * in some files but not others).
+ */
+
+/**
+ * Create a mock Probot context with all commonly-used octokit methods.
+ *
+ * @param {object} [overrides] — deep-merge overrides for the context
+ * @param {object} [overrides.payload] — merge into context.payload
+ * @returns {object} mock context
+ */
+function createMockContext (overrides = {}) {
+  const defaultPayload = {
+    action: 'opened',
+    pull_request: {
+      number: 1,
+      head: { sha: 'abc123', ref: 'feature-branch' },
+      base: { sha: 'def456', ref: 'main' },
+      user: { login: 'testuser' },
+      created_at: '2024-01-01T00:00:00Z',
+      merged: false,
+      merged_at: '2024-01-02T00:00:00Z',
+      html_url: 'https://github.com/owner/repo/pull/1'
+    },
+    repository: {
+      full_name: 'owner/repo'
+    },
+    issue: {
+      number: 1,
+      user: { login: 'testuser' },
+      html_url: 'https://github.com/owner/repo/issues/1',
+      created_at: '2024-01-01T00:00:00Z'
+    }
+  }
+
+  const payload = { ...defaultPayload, ...overrides.payload }
+
+  // Deep merge pull_request and issue if provided
+  if (overrides.payload && overrides.payload.pull_request) {
+    payload.pull_request = { ...defaultPayload.pull_request, ...overrides.payload.pull_request }
+  }
+  if (overrides.payload && overrides.payload.issue) {
+    payload.issue = { ...defaultPayload.issue, ...overrides.payload.issue }
+  }
+
+  return {
+    event: 'pull_request',
+    payload,
+    log: {
+      info: jest.fn(),
+      debug: jest.fn(),
+      warn: jest.fn()
+    },
+    octokit: {
+      pulls: {
+        get: jest.fn(),
+        listFiles: jest.fn(),
+        listCommits: jest.fn(),
+        createReviewRequest: jest.fn()
+      },
+      issues: {
+        addLabels: jest.fn(),
+        createComment: jest.fn(),
+        update: jest.fn()
+      },
+      repos: {
+        getBranch: jest.fn(),
+        createCommitStatus: jest.fn()
+      },
+      rest: {
+        search: {
+          issuesAndPullRequests: jest.fn()
+        },
+        repos: {
+          createCommitStatus: jest.fn()
+        }
+      }
+    },
+    issue: jest.fn((params = {}) => ({ owner: 'owner', repo: 'repo', issue_number: 1, ...params })),
+    repo: jest.fn((params = {}) => ({ owner: 'owner', repo: 'repo', ...params }))
+  }
+}
+
+module.exports = { createMockContext }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,12 @@ const pino = require('pino')
 const Stream = require('stream')
 const { Probot, ProbotOctokit } = require('probot')
 const myProbotApp = require('../index.js')
+const utils = require('../lib/utils')
+const labeler = require('../lib/labeler')
+const greetings = require('../lib/greetings')
+const issuelink = require('../lib/issuelink')
+const titleValidator = require('../lib/title_validator')
+const upToDateChecker = require('../lib/up_to_date_checker')
 
 describe('Boring Cyborg App Integration', () => {
   let probot
@@ -26,6 +32,32 @@ describe('Boring Cyborg App Integration', () => {
       }),
       log: pino(streamLogsToOutput)
     })
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  const prPayload = (action = 'opened', baseRef = 'main') => ({
+    action,
+    number: 1,
+    pull_request: {
+      number: 1,
+      head: { sha: 'abc123', ref: 'feature-branch' },
+      base: { sha: 'def456', ref: baseRef },
+      user: { login: 'testuser' },
+      created_at: '2024-01-01T00:00:00Z',
+      merged: false,
+      html_url: 'https://github.com/owner/repo/pull/1'
+    },
+    repository: {
+      id: 1,
+      node_id: 'R_1',
+      name: 'repo',
+      full_name: 'owner/repo',
+      owner: { login: 'owner' }
+    },
+    installation: { id: 1 }
   })
 
   describe('App Initialization', () => {
@@ -78,6 +110,189 @@ describe('Boring Cyborg App Integration', () => {
 
       // Verify onAny was called (this would fail if we used app.on('*'))
       expect(onAnySpy).toHaveBeenCalledWith(expect.any(Function))
+    })
+  })
+
+  describe('App Orchestration', () => {
+    it('should block all PR handlers when targetBranchFilter does not match', async () => {
+      jest.spyOn(utils, 'getConfig').mockResolvedValue({
+        targetBranchFilter: '^release/.*$',
+        labelPRBasedOnFilePath: { frontend: ['src/**'] }
+      })
+      const labelerSpy = jest.spyOn(labeler, 'addLabelsOnPr').mockResolvedValue()
+      const issueLinkSpy = jest.spyOn(issuelink, 'insertIssueLinkInPrDescription').mockResolvedValue()
+      const titleSpy = jest.spyOn(titleValidator, 'verifyTitles').mockResolvedValue()
+      const uptodateSpy = jest.spyOn(upToDateChecker, 'checkUpToDate').mockResolvedValue()
+      const greetingSpy = jest.spyOn(greetings, 'commentOnfirstPR').mockResolvedValue()
+
+      myProbotApp(probot, { getRouter: jest.fn() })
+
+      // PR targeting 'main' should be blocked by filter '^release/.*$'
+      await probot.receive({ id: '1', name: 'pull_request', payload: prPayload('opened', 'main') })
+
+      expect(labelerSpy).not.toHaveBeenCalled()
+      expect(issueLinkSpy).not.toHaveBeenCalled()
+      expect(titleSpy).not.toHaveBeenCalled()
+      expect(uptodateSpy).not.toHaveBeenCalled()
+      expect(greetingSpy).not.toHaveBeenCalled()
+    })
+
+    it('should pass through when targetBranchFilter matches', async () => {
+      jest.spyOn(utils, 'getConfig').mockResolvedValue({
+        targetBranchFilter: '^main$',
+        labelPRBasedOnFilePath: { frontend: ['src/**'] }
+      })
+      const labelerSpy = jest.spyOn(labeler, 'addLabelsOnPr').mockResolvedValue()
+
+      myProbotApp(probot, { getRouter: jest.fn() })
+
+      await probot.receive({ id: '1', name: 'pull_request', payload: prPayload('opened', 'main') })
+
+      expect(labelerSpy).toHaveBeenCalled()
+    })
+
+    it('should not apply branch filter to issues.opened events', async () => {
+      jest.spyOn(utils, 'getConfig').mockResolvedValue({
+        targetBranchFilter: '^release/.*$',
+        firstIssueWelcomeComment: 'Welcome!'
+      })
+      const greetingSpy = jest.spyOn(greetings, 'commentOnfirstIssue').mockResolvedValue()
+
+      myProbotApp(probot, { getRouter: jest.fn() })
+
+      await probot.receive({
+        id: '2',
+        name: 'issues',
+        payload: {
+          action: 'opened',
+          issue: {
+            number: 1,
+            user: { login: 'testuser' },
+            html_url: 'https://github.com/owner/repo/issues/1',
+            created_at: '2024-01-01T00:00:00Z'
+          },
+          repository: {
+            id: 1,
+            node_id: 'R_1',
+            name: 'repo',
+            full_name: 'owner/repo',
+            owner: { login: 'owner' }
+          },
+          installation: { id: 1 }
+        }
+      })
+
+      // Greetings should fire despite targetBranchFilter because issues bypass it
+      expect(greetingSpy).toHaveBeenCalled()
+    })
+
+    it('should invoke multiple handlers for the same event', async () => {
+      jest.spyOn(utils, 'getConfig').mockResolvedValue({
+        labelPRBasedOnFilePath: { frontend: ['src/**'] },
+        verifyTitles: { titleRegexp: '^fix:' }
+      })
+      const labelerSpy = jest.spyOn(labeler, 'addLabelsOnPr').mockResolvedValue()
+      const titleSpy = jest.spyOn(titleValidator, 'verifyTitles').mockResolvedValue()
+
+      myProbotApp(probot, { getRouter: jest.fn() })
+
+      await probot.receive({ id: '1', name: 'pull_request', payload: prPayload('opened', 'main') })
+
+      // Both handlers fire on the same event
+      expect(labelerSpy).toHaveBeenCalled()
+      expect(titleSpy).toHaveBeenCalled()
+    })
+  })
+
+  describe('Stats Endpoint', () => {
+    let routeHandler
+    let mockReq
+    let mockRes
+
+    beforeEach(() => {
+      const routes = {}
+      const mockRouter = {
+        get: jest.fn((path, handler) => { routes[path] = handler })
+      }
+      const mockGetRouter = jest.fn(() => mockRouter)
+
+      myProbotApp(probot, { getRouter: mockGetRouter })
+      routeHandler = routes['/stats']
+
+      mockRes = {
+        status: jest.fn(function () { return this }),
+        json: jest.fn()
+      }
+    })
+
+    it('should return 401 when no Authorization header', async () => {
+      process.env.STATS_API_KEY = 'test-key'
+      mockReq = { headers: {} }
+
+      await routeHandler(mockReq, mockRes)
+
+      expect(mockRes.status).toHaveBeenCalledWith(401)
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Missing or invalid Authorization header' })
+      delete process.env.STATS_API_KEY
+    })
+
+    it('should return 403 when API key is wrong', async () => {
+      process.env.STATS_API_KEY = 'correct-key'
+      mockReq = { headers: { authorization: 'Bearer wrong-key' } }
+
+      await routeHandler(mockReq, mockRes)
+
+      expect(mockRes.status).toHaveBeenCalledWith(403)
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Invalid API key' })
+      delete process.env.STATS_API_KEY
+    })
+
+    it('should return 500 when STATS_API_KEY is not configured', async () => {
+      delete process.env.STATS_API_KEY
+      mockReq = { headers: { authorization: 'Bearer some-key' } }
+
+      await routeHandler(mockReq, mockRes)
+
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'STATS_API_KEY not configured' })
+    })
+
+    it('should return stats with valid API key', async () => {
+      process.env.STATS_API_KEY = 'test-key'
+      mockReq = { headers: { authorization: 'Bearer test-key' } }
+
+      // Mock app.auth() to return an octokit with paginate
+      jest.spyOn(probot, 'auth').mockResolvedValue({
+        paginate: jest.fn().mockResolvedValue([
+          { id: 1, account: { login: 'org1', type: 'Organization' } },
+          { id: 2, account: { login: 'user1', type: 'User' } }
+        ]),
+        rest: { apps: { listInstallations: jest.fn() } }
+      })
+
+      await routeHandler(mockReq, mockRes)
+
+      expect(mockRes.json).toHaveBeenCalledWith({
+        totalInstallations: 2,
+        installations: [
+          { id: 1, account: 'org1', account_type: 'Organization' },
+          { id: 2, account: 'user1', account_type: 'User' }
+        ]
+      })
+      delete process.env.STATS_API_KEY
+    })
+
+    it('should return 500 when GitHub API call fails', async () => {
+      process.env.STATS_API_KEY = 'test-key'
+      mockReq = { headers: { authorization: 'Bearer test-key' } }
+
+      jest.spyOn(probot, 'auth').mockRejectedValue(new Error('GitHub API down'))
+
+      await routeHandler(mockReq, mockRes)
+
+      expect(mockRes.status).toHaveBeenCalledWith(500)
+      expect(mockRes.json).toHaveBeenCalledWith({ error: 'Failed to fetch stats' })
+      delete process.env.STATS_API_KEY
     })
   })
 })

--- a/test/issuelink.test.js
+++ b/test/issuelink.test.js
@@ -1,28 +1,12 @@
 /* eslint-disable no-template-curly-in-string */
 const { insertIssueLinkInPrDescription } = require('../lib/issuelink')
+const { createMockContext } = require('./helpers')
 
 describe('issuelink', () => {
   let context
 
   beforeEach(() => {
-    context = {
-      event: 'pull_request',
-      payload: {
-        action: 'opened',
-        pull_request: { number: 1, base: { ref: 'main' } }
-      },
-      log: {
-        info: jest.fn(),
-        debug: jest.fn(),
-        warn: jest.fn()
-      },
-      octokit: {
-        pulls: { get: jest.fn() },
-        issues: { update: jest.fn() }
-      },
-      issue: jest.fn((params) => ({ owner: 'owner', repo: 'repo', issue_number: 1, ...params })),
-      repo: jest.fn((params) => ({ owner: 'owner', repo: 'repo', ...params }))
-    }
+    context = createMockContext()
   })
 
   const baseConfig = (matchers) => ({
@@ -77,6 +61,41 @@ describe('issuelink', () => {
     expect(context.octokit.issues.update).toHaveBeenCalledWith(
       expect.objectContaining({ body: 'Issue link: MAIN-AIRFLOW-1234' })
     )
+  })
+
+  it('should handle null PR body without crashing', async () => {
+    context.octokit.pulls.get.mockResolvedValue(
+      prWithTitleAndBody('[AIRFLOW-1234] Fix X', null)
+    )
+
+    await insertIssueLinkInPrDescription(context, baseConfig({
+      jiraIssueMatch: {
+        titleIssueIdRegexp: '\\[(AIRFLOW-[0-9]{4})\\]',
+        descriptionIssueLink: 'LINK-${1}'
+      }
+    }))
+
+    // Should bail out (placeholder not found in null body) without throwing
+    expect(context.octokit.issues.update).not.toHaveBeenCalled()
+    expect(context.log.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Placeholder not found')
+    )
+  })
+
+  it('should propagate errors from issues.update (await fix)', async () => {
+    context.octokit.pulls.get.mockResolvedValue(
+      prWithTitleAndBody('[AIRFLOW-1234] Fix X', 'Issue link: PLACEHOLDER')
+    )
+    context.octokit.issues.update.mockRejectedValue(new Error('API rate limited'))
+
+    await expect(
+      insertIssueLinkInPrDescription(context, baseConfig({
+        jiraIssueMatch: {
+          titleIssueIdRegexp: '\\[(AIRFLOW-[0-9]{4})\\]',
+          descriptionIssueLink: 'LINK-${1}'
+        }
+      }))
+    ).rejects.toThrow('API rate limited')
   })
 
   it('uses a matcher whose targetBranchFilter matches the base ref', async () => {

--- a/test/labeler.test.js
+++ b/test/labeler.test.js
@@ -1,34 +1,11 @@
 const { addLabelsOnPr } = require('../lib/labeler')
+const { createMockContext } = require('./helpers')
 
 describe('labeler', () => {
   let context
 
   beforeEach(() => {
-    context = {
-      event: 'pull_request',
-      payload: {
-        action: 'opened',
-        pull_request: {
-          number: 1,
-          base: { ref: 'main' }
-        }
-      },
-      log: {
-        info: jest.fn(),
-        debug: jest.fn(),
-        warn: jest.fn()
-      },
-      octokit: {
-        pulls: {
-          get: jest.fn(),
-          listFiles: jest.fn()
-        },
-        issues: {
-          addLabels: jest.fn()
-        }
-      },
-      issue: jest.fn((params) => ({ owner: 'owner', repo: 'repo', pull_number: 1, ...params }))
-    }
+    context = createMockContext()
   })
 
   describe('addLabelsOnPr', () => {
@@ -59,7 +36,7 @@ describe('labeler', () => {
       expect(context.octokit.issues.addLabels).toHaveBeenCalledWith({
         owner: 'owner',
         repo: 'repo',
-        pull_number: 1,
+        issue_number: 1,
         labels: ['frontend']
       })
     })
@@ -125,6 +102,39 @@ describe('labeler', () => {
       expect(context.octokit.issues.addLabels).not.toHaveBeenCalled()
     })
 
+    it('should match non-trivial glob patterns correctly', async () => {
+      const config = {
+        labelPRBasedOnFilePath: {
+          migrations: ['db/migrations/**/*.sql'],
+          tests: ['**/__tests__/**', '**/*.test.js'],
+          config: ['*.json', '*.yml', '!package-lock.json']
+        }
+      }
+
+      context.octokit.pulls.get.mockResolvedValue({
+        data: {
+          url: 'https://api.github.com/repos/owner/repo/pulls/1',
+          labels: []
+        }
+      })
+
+      context.octokit.pulls.listFiles.mockResolvedValue({
+        data: [
+          { filename: 'db/migrations/2024/001_add_users.sql' },
+          { filename: 'src/__tests__/app.test.js' },
+          { filename: 'tsconfig.json' }
+        ]
+      })
+
+      await addLabelsOnPr(context, config)
+
+      expect(context.octokit.issues.addLabels).toHaveBeenCalledWith(
+        expect.objectContaining({
+          labels: expect.arrayContaining(['migrations', 'tests', 'config'])
+        })
+      )
+    })
+
     it('should skip labeling on PR updates when disabled', async () => {
       const config = {
         labelPRBasedOnFilePath: {
@@ -168,7 +178,7 @@ describe('labeler', () => {
       expect(context.octokit.issues.addLabels).toHaveBeenCalledWith({
         owner: 'owner',
         repo: 'repo',
-        pull_number: 1,
+        issue_number: 1,
         labels: ['frontend']
       })
     })
@@ -202,7 +212,7 @@ describe('labeler', () => {
       expect(context.octokit.issues.addLabels).toHaveBeenCalledWith({
         owner: 'owner',
         repo: 'repo',
-        pull_number: 1,
+        issue_number: 1,
         labels: ['backend']
       })
     })

--- a/test/reviewer.test.js
+++ b/test/reviewer.test.js
@@ -1,29 +1,11 @@
 const { addReviewersOnPr } = require('../lib/reviewer')
+const { createMockContext } = require('./helpers')
 
 describe('reviewer', () => {
   let context
 
   beforeEach(() => {
-    context = {
-      event: 'pull_request',
-      payload: {
-        action: 'labeled',
-        pull_request: { number: 1, base: { ref: 'main' } }
-      },
-      log: {
-        info: jest.fn(),
-        debug: jest.fn(),
-        warn: jest.fn()
-      },
-      octokit: {
-        pulls: {
-          get: jest.fn(),
-          createReviewRequest: jest.fn()
-        }
-      },
-      issue: jest.fn(() => ({ owner: 'owner', repo: 'repo', pull_number: 1 })),
-      repo: jest.fn((params) => ({ owner: 'owner', repo: 'repo', ...params }))
-    }
+    context = createMockContext({ payload: { action: 'labeled' } })
   })
 
   describe('addReviewersOnPr', () => {
@@ -207,6 +189,31 @@ describe('reviewer', () => {
       await addReviewersOnPr(context, config)
 
       expect(context.log.warn).toHaveBeenCalled()
+      expect(context.octokit.pulls.createReviewRequest).not.toHaveBeenCalled()
+    })
+
+    it('should not make review request when all reviewers are the PR author', async () => {
+      const config = {
+        addReviewerBasedOnLabel: {
+          labels: {
+            frontend: ['author']
+          }
+        }
+      }
+
+      context.octokit.pulls.get.mockResolvedValue({
+        data: {
+          url: 'https://api.github.com/repos/owner/repo/pulls/1',
+          number: 1,
+          user: { login: 'author' },
+          labels: [{ name: 'frontend' }],
+          requested_reviewers: []
+        }
+      })
+
+      await addReviewersOnPr(context, config)
+
+      // After removing the author, no reviewers remain — should not call API
       expect(context.octokit.pulls.createReviewRequest).not.toHaveBeenCalled()
     })
 

--- a/test/title_validator.test.js
+++ b/test/title_validator.test.js
@@ -1,29 +1,11 @@
 const { verifyTitles } = require('../lib/title_validator')
+const { createMockContext } = require('./helpers')
 
 describe('title_validator', () => {
   let context
 
   beforeEach(() => {
-    context = {
-      log: {
-        info: jest.fn(),
-        debug: jest.fn(),
-        warn: jest.fn()
-      },
-      octokit: {
-        pulls: {
-          get: jest.fn(),
-          listCommits: jest.fn()
-        },
-        rest: {
-          repos: {
-            createCommitStatus: jest.fn()
-          }
-        }
-      },
-      issue: jest.fn(() => ({ owner: 'owner', repo: 'repo', pull_number: 1 })),
-      repo: jest.fn((params) => ({ owner: 'owner', repo: 'repo', ...params }))
-    }
+    context = createMockContext()
   })
 
   describe('verifyTitles', () => {

--- a/test/up_to_date_checker.test.js
+++ b/test/up_to_date_checker.test.js
@@ -1,0 +1,218 @@
+const { checkUpToDate } = require('../lib/up_to_date_checker')
+const { createMockContext } = require('./helpers')
+
+describe('up_to_date_checker', () => {
+  let context
+
+  beforeEach(() => {
+    context = createMockContext({
+      payload: {
+        pull_request: {
+          head: { sha: 'context-head-sha' },
+          base: { sha: 'target-branch-sha', ref: 'main' }
+        }
+      }
+    })
+  })
+
+  const setupPr = (headRef = 'feature-branch') => {
+    context.octokit.pulls.get.mockResolvedValue({
+      data: {
+        url: 'https://api.github.com/repos/owner/repo/pulls/1',
+        head: { sha: 'pr-head-sha', ref: headRef },
+        base: { sha: 'target-branch-sha', ref: 'main' }
+      }
+    })
+  }
+
+  const setupFiles = (filenames) => {
+    context.octokit.pulls.listFiles.mockResolvedValue({
+      data: filenames.map(f => ({ filename: f }))
+    })
+  }
+
+  const setupBranches = (headSha, targetSha) => {
+    context.octokit.repos.getBranch
+      .mockResolvedValueOnce({ data: { commit: { sha: headSha } } })
+      .mockResolvedValueOnce({ data: { commit: { sha: targetSha } } })
+  }
+
+  describe('checkUpToDate', () => {
+    it('should set success status when PR is up to date', async () => {
+      const config = {
+        checkUpToDate: {
+          files: ['migrations/*'],
+          targetBranch: 'master'
+        }
+      }
+
+      setupPr()
+      setupFiles(['migrations/001.sql'])
+      // target branch sha matches the context base sha => up to date
+      setupBranches('fresh-head-sha', 'target-branch-sha')
+
+      await checkUpToDate(context, config)
+
+      expect(context.octokit.repos.createCommitStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: 'success',
+          context: 'Up-to-date Checker',
+          description: 'PR is up to date with base branch'
+        })
+      )
+    })
+
+    it('should set pending status when PR is NOT up to date, using fresh head SHA', async () => {
+      const config = {
+        checkUpToDate: {
+          files: ['migrations/*'],
+          targetBranch: 'master'
+        }
+      }
+
+      setupPr()
+      setupFiles(['migrations/001.sql'])
+      // target branch sha differs from context base sha => not up to date
+      setupBranches('fresh-head-sha', 'different-target-sha')
+
+      await checkUpToDate(context, config)
+
+      const statusCall = context.octokit.repos.createCommitStatus.mock.calls[0][0]
+      expect(statusCall).toMatchObject({
+        state: 'pending',
+        context: 'Up-to-date Checker',
+        description: 'PR is not up to date with base branch'
+      })
+      // The status must be posted against the fresh head SHA from getBranch,
+      // not the stale context.payload.pull_request.head.sha
+      expect(statusCall.sha).toBe('fresh-head-sha')
+    })
+
+    it('should set success status when no files match the pattern', async () => {
+      const config = {
+        checkUpToDate: {
+          files: ['migrations/*'],
+          targetBranch: 'master'
+        }
+      }
+
+      setupPr()
+      setupFiles(['src/app.js', 'README.md'])
+      // Branches shouldn't even be fetched, but set up to avoid unhandled rejection
+      setupBranches('head-sha', 'target-sha')
+
+      await checkUpToDate(context, config)
+
+      // Should post success since no tracked files were modified
+      expect(context.octokit.repos.createCommitStatus).toHaveBeenCalledWith(
+        expect.objectContaining({
+          state: 'success',
+          description: 'PR is up to date with base branch'
+        })
+      )
+      // getBranch should NOT be called when no files match
+      expect(context.octokit.repos.getBranch).not.toHaveBeenCalled()
+    })
+
+    it('should do nothing when config is not present', async () => {
+      const config = {}
+
+      await checkUpToDate(context, config)
+
+      expect(context.octokit.pulls.get).not.toHaveBeenCalled()
+      expect(context.octokit.repos.createCommitStatus).not.toHaveBeenCalled()
+    })
+
+    it('should work with legacy config format (bare array)', async () => {
+      // Backwards compatibility: config value is directly an array of file patterns
+      const config = {
+        checkUpToDate: ['migrations/*', 'schema/*.sql']
+      }
+
+      setupPr()
+      setupFiles(['schema/tables.sql'])
+      setupBranches('head-sha', 'target-branch-sha')
+
+      await checkUpToDate(context, config)
+
+      // Should use default targetBranch 'master'
+      expect(context.octokit.repos.getBranch).toHaveBeenCalledWith(
+        expect.objectContaining({ branch: 'master' })
+      )
+      expect(context.octokit.repos.createCommitStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'success' })
+      )
+    })
+
+    it('should return early when targetBranch is set but files key is missing', async () => {
+      // This was a crash bug: ignore().add(undefined) threw TypeError
+      const config = {
+        checkUpToDate: {
+          targetBranch: 'main'
+        }
+      }
+
+      setupPr()
+
+      await checkUpToDate(context, config)
+
+      // Should return early without crashing, no file listing or status check
+      expect(context.octokit.pulls.listFiles).not.toHaveBeenCalled()
+      expect(context.octokit.repos.createCommitStatus).not.toHaveBeenCalled()
+    })
+
+    it('should return early when files key is present but null', async () => {
+      const config = {
+        checkUpToDate: {
+          files: null,
+          targetBranch: 'main'
+        }
+      }
+
+      setupPr()
+
+      await checkUpToDate(context, config)
+
+      expect(context.octokit.pulls.listFiles).not.toHaveBeenCalled()
+      expect(context.octokit.repos.createCommitStatus).not.toHaveBeenCalled()
+    })
+
+    it('should use custom targetBranch from config', async () => {
+      const config = {
+        checkUpToDate: {
+          files: ['migrations/*'],
+          targetBranch: 'develop'
+        }
+      }
+
+      setupPr()
+      setupFiles(['migrations/001.sql'])
+      setupBranches('head-sha', 'target-branch-sha')
+
+      await checkUpToDate(context, config)
+
+      // getBranch is called twice: once for head branch, once for target branch
+      const targetBranchCall = context.octokit.repos.getBranch.mock.calls[1][0]
+      expect(targetBranchCall.branch).toBe('develop')
+    })
+
+    it('should post success status using PR head SHA when up to date', async () => {
+      const config = {
+        checkUpToDate: {
+          files: ['migrations/*'],
+          targetBranch: 'master'
+        }
+      }
+
+      setupPr('my-feature')
+      setupFiles(['migrations/001.sql'])
+      setupBranches('fresh-head-sha', 'target-branch-sha')
+
+      await checkUpToDate(context, config)
+
+      // When up to date, status uses pr.head.sha from pulls.get (not getBranch)
+      const statusCall = context.octokit.repos.createCommitStatus.mock.calls[0][0]
+      expect(statusCall.sha).toBe('pr-head-sha')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Fix 2 bugs discovered during testing analysis: missing `await` in issuelink.js and a crash in up_to_date_checker.js when `filePatterns` is undefined/null
- Add 29 meaningful tests bringing the total from 55 to 84, with statement coverage from ~85% to 96.27%
- Create shared test helper (`createMockContext()`) to eliminate mock drift across 6 test files

## Bug Fixes

**`lib/issuelink.js:70` — missing `await`**: `context.octokit.issues.update()` was fire-and-forget. API failures (rate limits, 500s) were silently swallowed. Now properly awaited so errors propagate to the caller.

**`lib/up_to_date_checker.js` — undefined `filePatterns` crash**: When config had `targetBranch` but no `files` key, or when `files` was `null`, `ignore().add(undefined)` threw a TypeError crashing the handler. Now returns early with a debug log.

## New Tests

| Area | Tests | What they catch |
|------|-------|----------------|
| `up_to_date_checker.js` (was 0%) | 9 | SHA comparison logic, legacy config format, crash bug, null files, custom targetBranch |
| App orchestration (`index.js`) | 4 | `withBranchFilter` blocks/passes correctly, `issues.opened` bypasses branch filter, multi-handler fan-out |
| Stats endpoint (`index.js`) | 5 | Auth bypass (401/403), missing STATS_API_KEY (500), happy path, API failure handling |
| Greetings edge cases | 6 | Search query construction verification for all 3 functions, 404 vs 500 error handling |
| Issuelink edge cases | 2 | Null PR body handling, `await` fix error propagation |
| Reviewer edge case | 1 | All configured reviewers are the PR author → no empty API call |
| Labeler edge case | 1 | Non-trivial glob patterns (nested paths, negation) |

## Design Rationale

**Why spy on modules instead of using nock for orchestration tests?** The `withBranchFilter` wrapper calls `utils.getConfig()` which uses Probot's `context.config()` internally — nocking that requires matching Probot's internal URL patterns across versions. Spying on `getConfig` tests the real orchestration logic (event routing → branch filter → handler dispatch) without coupling to Probot config internals.

**Why a shared `createMockContext()` instead of inline mocks?** All 6 test files had hand-rolled context mocks with subtle inconsistencies (e.g., `context.issue()` returning `pull_number` in some files, `issue_number` in others). The factory enforces a single consistent shape. The labeler tests were actually asserting incorrect `pull_number` values — `context.issue()` returns `issue_number` per Probot's API.

**Why remove the "handler isolation" test?** Both subagent reviewers flagged it as testing Probot's behavior (independent handler execution), not our code. `withBranchFilter` wraps a single handler; Probot's event system handles fan-out.

## Known Pre-existing Issues (not addressed here)

- `greetings.js` checks `err.code` but modern Octokit uses `err.status` for HTTP errors — the 404 catch may not work in production
- `pulls.listFiles` in labeler and up_to_date_checker doesn't paginate — PRs with 100+ files get incomplete results
- `reviewer.js` collects `existingReviewers` but never filters them out, so it can re-request already-assigned reviewers